### PR TITLE
Feat: 카카오 토큰 기반 기존 회원 유무 판별 API 추가

### DIFF
--- a/baebae-BE/src/main/java/com/web/baebaeBE/application/member/MemberApplication.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/application/member/MemberApplication.java
@@ -33,6 +33,17 @@ public class MemberApplication {
     }
   }
 
+  public MemberResponse.isExistingUserResponse checkIsExisting(HttpServletRequest httpServletRequest){
+    //카카오 토큰으로 정보 가져옴
+    KakaoUserInfoDto kakaoUserInfo = loginService.getKakaoUserInfo(httpServletRequest);
+
+    //이미 회원이 존재하면 true, 아니면 false
+    if(loginService.isExistingUser(kakaoUserInfo.getKakaoAccount().getEmail()))
+      return new MemberResponse.isExistingUserResponse(true);
+    else
+      return new MemberResponse.isExistingUserResponse(false);
+  }
+
 
   public MemberResponse.AccessTokenResponse newAccessToken(String refreshToken) {
     return manageTokenService.issueNewAccessToken(refreshToken); // 함수 호출

--- a/baebae-BE/src/main/java/com/web/baebaeBE/global/config/SwaggerConfig.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/global/config/SwaggerConfig.java
@@ -31,7 +31,7 @@ public class SwaggerConfig {
                 .bearerFormat("JWT")
                 .scheme("Bearer");
 
-        Components components = new Components().addSecuritySchemes("token", securityScheme);
+        Components components = new Components().addSecuritySchemes("bearerAuth", securityScheme);
 
         return new OpenAPI()
                 .info(info)

--- a/baebae-BE/src/main/java/com/web/baebaeBE/global/security/SecurityConstants.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/global/security/SecurityConstants.java
@@ -4,7 +4,7 @@ public final class SecurityConstants {
 
     public static final String[] NO_AUTH_LIST = {
             // oAuth2 인증 제외
-            "/api/oauth/kakao", "/favicon.ico", "/oauth/kakao/callback", "/api/oauth/login",
+            "/api/oauth/kakao", "/favicon.ico", "/oauth/kakao/callback", "/api/oauth/login", "/api/oauth/isExisting",
             // Swagger 제외 과정
             "/v3/**", "/swagger-ui/**",
             // Error 페이지

--- a/baebae-BE/src/main/java/com/web/baebaeBE/infra/member/repository/MemberRepository.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/infra/member/repository/MemberRepository.java
@@ -13,4 +13,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   boolean existsByEmail(String email);
 
   Optional<Member> findByRefreshToken(String refreshToken);
+
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/member/MemberController.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/member/MemberController.java
@@ -33,6 +33,14 @@ public class MemberController implements MemberApi {
     return ResponseEntity.ok(memberApplication.login(httpServletRequest, signUpRequest));
   }
 
+  //회원가입 유무 판별
+  @GetMapping("/isExisting")
+  public ResponseEntity<MemberResponse.isExistingUserResponse> isExistingUser(
+          HttpServletRequest httpServletRequest
+  ) {
+    return ResponseEntity.ok(memberApplication.checkIsExisting(httpServletRequest));
+  }
+
 
   // Access Token 재발급
   @PostMapping("/token/refresh")
@@ -64,4 +72,8 @@ public class MemberController implements MemberApi {
 
     return ResponseEntity.ok().build();
   }
+
+
+
+
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/member/api/MemberApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/member/api/MemberApi.java
@@ -54,6 +54,33 @@ public interface MemberApi {
             HttpServletRequest httpServletRequest
     );
 
+    @Operation(
+            summary = "회원가입 유무 체크",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @Parameter(
+            in = ParameterIn.HEADER,
+            name = "Authorization", required = true,
+            schema = @Schema(type = "string"),
+            description = "Bearer [카카오 Access 토큰]")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "기존 회원",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\n" +
+                                    "  \"isExisting\": \"true\"\n" +
+                                    "}"))
+            ),
+            @ApiResponse(responseCode = "200", description = "새로운 회원",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\n" +
+                                    "  \"isExisting\": \"false\"\n" +
+                                    "}"))
+            )
+    })
+    public ResponseEntity<MemberResponse.isExistingUserResponse> isExistingUser(
+            HttpServletRequest httpServletRequest
+    );
+
 
 
     @Operation(summary = "Access Token 재발급")

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/member/dto/MemberResponse.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/member/dto/MemberResponse.java
@@ -82,5 +82,12 @@ public class MemberResponse {
 
   }
 
-
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class isExistingUserResponse {
+    private Boolean isExisting;
+  }
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
> ex) #25

### 📝PR 설명
프론트에서 필요한 기존 회원 유무 판별 API를 추가했습니다.
이는 카카오 토큰 기반으로 이메일 정보를 추출하여 기존 DB의 email과 비교하여 판별하는 로직을 가지고 있습니다.

### 🔨작업 내용
- [ ] 기존회원 유무 판별 API 추가

### 💎결과 (사진 및 작업 결과)
