### PR TITLE
Feat: 닉네임 기반 회원 ID 반환 API 추가

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -7,12 +7,12 @@
         <processorPath useClasspath="false">
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.24/13a394eed5c4f9efb2a6d956e2086f1d81e857d9/lombok-1.18.24.jar" />
         </processorPath>
-        <module name="baebae-BE.baebae-BE.main~1" />
+        <module name="baebae-BE.baebae-BE.main" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel>
-      <module name="baebae-BE.baebae-BE.main" target="17" />
-      <module name="baebae-BE.baebae-BE.test" target="17" />
+      <module name="baebae-BE.baebae-BE.main~1" target="17" />
+      <module name="baebae-BE.baebae-BE.test~1" target="17" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/baebae-BE/src/main/java/com/web/baebaeBE/application/manage/member/ManageMemberApplication.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/application/manage/member/ManageMemberApplication.java
@@ -45,4 +45,8 @@ public class ManageMemberApplication {
         manageMemberService.deleteMember(memberId);
     }
 
+    public Long getMemberIdByNickname(String nickname) {
+        return manageMemberService.getMemberIdByNickname(nickname);
+    }
+
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/manage/member/service/ManageMemberService.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/manage/member/service/ManageMemberService.java
@@ -73,4 +73,11 @@ public class ManageMemberService {
         if(!member.getEmail().equals(memberEmail))
             throw new BusinessException(ManageMemberError.NOT_VERIFY_MEMBET_WITH_TOKEN);
     }
+
+    // 닉네임 기반으로 memberId를 찾아오는 메서드
+    public Long getMemberIdByNickname(String nickname) {
+        return memberRepository.findByNickname(nickname)
+                .map(Member::getId)
+                .orElseThrow(() -> new BusinessException(MemberError.NOT_EXIST_MEMBER));
+    }
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/infra/member/repository/MemberRepository.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/infra/member/repository/MemberRepository.java
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+
   Optional<Member> findByEmail(String email);
+  Optional<Member> findByNickname(String nickname);
 
   boolean existsByEmail(String email);
   boolean existsByNickname(String nickname);

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/ManageMemberController.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/ManageMemberController.java
@@ -31,6 +31,12 @@ public class ManageMemberController implements ManageMemberApi {
 
     return ResponseEntity.ok(memberInformation);
   }
+  @GetMapping("/members/nickname/{nickname}")
+  public Long getMemberIdByNickname(
+          @PathVariable String nickname
+  ) {
+    return manageMemberApplication.getMemberIdByNickname(nickname);
+  }
 
   @PatchMapping(value = "/profile-image/{memberId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<ManageMemberResponse.ObjectUrlResponse> updateProfileImage(
@@ -67,6 +73,8 @@ public class ManageMemberController implements ManageMemberApi {
     manageMemberApplication.deleteMember(memberId, httpServletRequest);
     return ResponseEntity.ok().build();
   }
+
+
 }
 
 

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/api/ManageMemberApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/api/ManageMemberApi.java
@@ -54,6 +54,37 @@ public interface ManageMemberApi {
     ResponseEntity<ManageMemberResponse.MemberInformationResponse> getMemberInformation(@PathVariable Long id);
 
 
+    @Operation(
+            summary = "회원 id 조회",
+            description = "주어진 회원의 닉네임 정보를 바탕으로 회원의 id를 조회합니다. ",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @Parameter(
+            in = ParameterIn.HEADER,
+            name = "Authorization", required = true,
+            schema = @Schema(type = "string"),
+            description = "Bearer [Access 토큰]")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = Long.class))),
+            @ApiResponse(responseCode = "401", description = "토큰 인증 실패",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\n" +
+                                    "  \"errorCode\": \"T-002\",\n" +
+                                    "  \"message\": \"해당 토큰은 유효한 토큰이 아닙니다.\"\n" +
+                                    "}"))
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\n" +
+                                    "  \"errorCode\": \"M-002\",\n" +
+                                    "  \"message\": \"존재하지 않는 회원입니다.\"\n" +
+                                    "}"))
+            )
+    })
+    @GetMapping("/members/nickname/{nickname}")
+    Long getMemberIdByNickname(@PathVariable String nickname);
 
     @Operation(
             summary = "프로필 사진 업데이트",


### PR DESCRIPTION
### #️⃣연관된 이슈
> #42

### 📝PR 설명
닉네임 정보를 바탕으로 회원 테이블을 조회해 알맞은 회원의 ID를 찾아오는 API 개발

### 🔨작업 내용
- [x] 닉네임 기반 회원 ID 반환 API 추가
- [ ]

### 💎결과 (사진 및 작업 결과)
