### PR TITLE
Refactor/nickname/#49 [Refactor] 닉네임 조회 API 수정

### DIFF
--- a/baebae-BE/src/main/java/com/web/baebaeBE/application/manage/member/ManageMemberApplication.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/application/manage/member/ManageMemberApplication.java
@@ -52,7 +52,7 @@ public class ManageMemberApplication {
         manageMemberService.deleteMember(memberId);
     }
 
-    public Long getMemberIdByNickname(String nickname) {
+    public ManageMemberResponse.MemberIdResponse getMemberIdByNickname(String nickname) {
         return manageMemberService.getMemberIdByNickname(nickname);
     }
 

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/manage/member/service/ManageMemberService.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/manage/member/service/ManageMemberService.java
@@ -90,9 +90,7 @@ public class ManageMemberService {
     }
 
     // 닉네임 기반으로 memberId를 찾아오는 메서드
-    public Long getMemberIdByNickname(String nickname) {
-        return memberRepository.findByNickname(nickname)
-                .map(Member::getId)
-                .orElseThrow(() -> new BusinessException(MemberError.NOT_EXIST_MEMBER));
+    public ManageMemberResponse.MemberIdResponse getMemberIdByNickname(String nickname) {
+        return ManageMemberResponse.MemberIdResponse.of(memberRepository.findByNickname(nickname).get().getId());
     }
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/global/security/SecurityConstants.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/global/security/SecurityConstants.java
@@ -5,7 +5,7 @@ public final class SecurityConstants {
     public static final String[] NO_AUTH_LIST = {
             // oAuth2 인증 제외
             "/api/oauth/kakao", "/favicon.ico", "/oauth/kakao/callback",
-            "/api/oauth/login", "/api/oauth/isExisting", "/api/oauth/nickname/isExisting",
+            "/api/oauth/login", "/api/oauth/isExisting", "/api/oauth/nickname/isExisting", "/api/member/nickname/{nickname}",
             // Swagger 제외 과정
             "/v3/**", "/swagger-ui/**",
             // Error 페이지

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/ManageMemberController.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/ManageMemberController.java
@@ -34,7 +34,7 @@ public class ManageMemberController implements ManageMemberApi {
 
     return ResponseEntity.ok(memberInformation);
   }
-  @GetMapping("/members/nickname/{nickname}")
+  @GetMapping("/nickname/{nickname}")
   public Long getMemberIdByNickname(
           @PathVariable String nickname
   ) {

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/ManageMemberController.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/ManageMemberController.java
@@ -35,10 +35,10 @@ public class ManageMemberController implements ManageMemberApi {
     return ResponseEntity.ok(memberInformation);
   }
   @GetMapping("/nickname/{nickname}")
-  public Long getMemberIdByNickname(
+  public ResponseEntity<ManageMemberResponse.MemberIdResponse> getMemberIdByNickname(
           @PathVariable String nickname
   ) {
-    return manageMemberApplication.getMemberIdByNickname(nickname);
+    return ResponseEntity.ok(manageMemberApplication.getMemberIdByNickname(nickname));
   }
 
   @PatchMapping(value = "/profile-image/{memberId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/api/ManageMemberApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/api/ManageMemberApi.java
@@ -56,14 +56,8 @@ public interface ManageMemberApi {
 
     @Operation(
             summary = "회원 id 조회",
-            description = "주어진 회원의 닉네임 정보를 바탕으로 회원의 id를 조회합니다. ",
-            security = @SecurityRequirement(name = "bearerAuth")
+            description = "주어진 회원의 닉네임 정보를 바탕으로 회원의 id를 조회합니다. "
     )
-    @Parameter(
-            in = ParameterIn.HEADER,
-            name = "Authorization", required = true,
-            schema = @Schema(type = "string"),
-            description = "Bearer [Access 토큰]")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(mediaType = "application/json",
@@ -83,8 +77,8 @@ public interface ManageMemberApi {
                                     "}"))
             )
     })
-    @GetMapping("/members/nickname/{nickname}")
-    Long getMemberIdByNickname(@PathVariable String nickname);
+    @GetMapping("/nickname/{nickname}")
+    ResponseEntity<ManageMemberResponse.MemberIdResponse> getMemberIdByNickname(@PathVariable String nickname);
 
     @Operation(
             summary = "프로필 사진 업데이트",

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/dto/ManageMemberResponse.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/dto/ManageMemberResponse.java
@@ -48,6 +48,21 @@ public class ManageMemberResponse {
     }
   }
 
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class MemberIdResponse{
+    private Long memberId;
+
+    public static MemberIdResponse of (Long memberId){
+      return MemberIdResponse.builder()
+              .memberId(memberId)
+              .build();
+    }
+  }
+
 
 
 


### PR DESCRIPTION
### #️⃣연관된 이슈
> ex) #49

### 📝PR 설명
비즈니스 로직 수정으로 인해, 비 로그인 사용자도 회원 조회 API를 사용할 수 있게 수정되었습니다.
따라서, 프론트측 요청에 따라 회원 조회 API를 스프링 시큐리티 제외목록에 추가하였고,
추가적으로, 수정중에 컨트롤러 코드에 모호한 부분이 있는거같아 좀 더 기능을 명확히 하기 위해,Response DTO 수정 및 해당 컨트롤러 URI 수정을 진행하였습니다.

### 🔨작업 내용
- [ ] 닉네임 조회 API URL 수정
- [ ] 시큐리티 인증 제외 목록 추가
- [ ] 닉네임 조회 Response DTO 수정

### 💎결과 (사진 및 작업 결과)
