### PR TITLE
Feature/category/#51

### DIFF
--- a/baebae-BE/src/main/java/com/web/baebaeBE/application/answer/AnswerApplication.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/application/answer/AnswerApplication.java
@@ -12,6 +12,7 @@ import com.web.baebaeBE.infra.question.entity.Question;
 import com.web.baebaeBE.infra.question.repository.QuestionRepository;
 import com.web.baebaeBE.presentation.answer.dto.AnswerCreateRequest;
 import com.web.baebaeBE.presentation.answer.dto.AnswerDetailResponse;
+import com.web.baebaeBE.presentation.answer.dto.AnswerResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +40,13 @@ public class AnswerApplication {
         Answer answerEntity = answerMapper.toEntity(request, question, member);
         Answer savedAnswerEntity = answerService.createAnswer(answerEntity, imageFiles, audioFile);
         return answerMapper.toDomain(savedAnswerEntity);
+    }
+
+    public List<AnswerResponse> getAnswersByMemberId(Long memberId) {
+        List<Answer> answers = answerService.getAnswersByMemberId(memberId);
+        return answers.stream()
+                .map(AnswerResponse::of)
+                .collect(Collectors.toList());
     }
 
     public Page<AnswerDetailResponse> getAllAnswers(Long memberId, Pageable pageable) {

--- a/baebae-BE/src/main/java/com/web/baebaeBE/application/category/CategoryApplication.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/application/category/CategoryApplication.java
@@ -24,7 +24,7 @@ public class CategoryApplication{
         Category category =
                 categoryService.createCategory(memberId, categoryImage, createCategory.getCategoryName());
 
-        return categoryService.createAnswersToCategory(category.getCategoryId(), createCategory.getAnswerId());
+        return categoryService.createAnswersToCategory(category.getCategoryId(), createCategory.getAnswerIds());
     }
     public CategoryResponse.CategoryListResponse getCategoriesByMember(Long memberId) {
         return categoryService.getCategoriesByMember(memberId);

--- a/baebae-BE/src/main/java/com/web/baebaeBE/application/manage/member/ManageMemberApplication.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/application/manage/member/ManageMemberApplication.java
@@ -31,6 +31,11 @@ public class ManageMemberApplication {
         return manageMemberService.getMember(memberId);
     }
 
+    public ManageMemberResponse.ProfileImageResponse getProfileImage(Long memberId) {
+        String imageUrl = manageMemberService.getProfileImage(memberId);
+        return ManageMemberResponse.ProfileImageResponse.of(imageUrl);
+    }
+
     public ManageMemberResponse.ObjectUrlResponse updateProfileImage(Long memberId, MultipartFile image) throws IOException {
         manageMemberService.updateProfileImage(memberId, image);
         Member member = memberRepository.findById(memberId)

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/service/AnswerService.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/service/AnswerService.java
@@ -65,6 +65,10 @@ public class AnswerService {
 
         return answer;
     }
+    
+    public List<Answer> getAnswersByMemberId(Long memberId) {
+        return answerRepository.findByMemberId(memberId);
+    }
 
     @Transactional
     public Page<Answer> getAllAnswers(Long memberId, Pageable pageable) {

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/category/service/CategoryService.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/category/service/CategoryService.java
@@ -56,16 +56,22 @@ private final EntityManager entityManager; // Answer 엔티티 프록시 가져�
         return categoryRepository.save(category);
     }
 
-    public CategoryResponse.CategoryInformationResponse createAnswersToCategory(Long categoryId, Long answerId) {
-        Category category = categoryRepository.findById(categoryId).get();
-        //.orElseThrow(() -> new BusinessException(CategoryError.CATEGORY_NOT_FOUND));
+    public CategoryResponse.CategoryInformationResponse createAnswersToCategory(Long categoryId, List<Long> answerIds) {
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new BusinessException(CategoryError.CATEGORY_NOT_FOUND));
 
         // 카테고리에 Answer 추가
-        Answer answer = answerRepository.findByAnswerId(answerId).get();
-        categoryAnswerRepository.save(CategorizedAnswer.builder()
-                .category(category)
-                .answer(answer)
-                .build());
+        for (Long answerId : answerIds) {
+            System.out.println(answerId);
+            Answer answer = answerRepository.findByAnswerId(answerId)
+                    .orElseThrow(() -> new BusinessException(AnswerError.NO_EXIST_ANSWER));
+            CategorizedAnswer categorizedAnswer = CategorizedAnswer.builder()
+                    .category(category)
+                    .answer(answer)
+                    .build();
+            category.getCategoryAnswers().add(categorizedAnswer); // CategorizedAnswer를 Category의 CategorizedAnswer 리스트에 추가
+            categoryAnswerRepository.save(categorizedAnswer);
+        }
 
         return CategoryResponse.CategoryInformationResponse.of(category);
     }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/manage/member/service/ManageMemberService.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/manage/member/service/ManageMemberService.java
@@ -33,6 +33,11 @@ public class ManageMemberService {
 
         return ManageMemberResponse.MemberInformationResponse.of(member);
     }
+    public String getProfileImage(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(MemberError.NOT_EXIST_MEMBER));
+        return member.getProfileImage();
+    }
 
     public void updateProfileImage(Long memberId, MultipartFile image) throws IOException {
         String imageUrl = convertImageToObject(memberId, image);

--- a/baebae-BE/src/main/java/com/web/baebaeBE/global/security/SecurityConstants.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/global/security/SecurityConstants.java
@@ -6,6 +6,7 @@ public final class SecurityConstants {
             // oAuth2 인증 제외
             "/api/oauth/kakao", "/favicon.ico", "/oauth/kakao/callback",
             "/api/oauth/login", "/api/oauth/isExisting", "/api/oauth/nickname/isExisting",
+            "/api/member/profile-image/{memberId}",
             // Swagger 제외 과정
             "/v3/**", "/swagger-ui/**",
             // Error 페이지

--- a/baebae-BE/src/main/java/com/web/baebaeBE/infra/answer/repository/AnswerJpaRepository.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/infra/answer/repository/AnswerJpaRepository.java
@@ -5,6 +5,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AnswerJpaRepository extends JpaRepository<Answer, Long> {
     Page<Answer> findAllByMemberId(Long memberId, Pageable pageable);
+
+    List<Answer> findByMemberId(Long memberId);
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/infra/answer/repository/AnswerRepository.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/infra/answer/repository/AnswerRepository.java
@@ -4,10 +4,12 @@ import com.web.baebaeBE.infra.answer.entity.Answer;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AnswerRepository {
     Optional<Answer> findByAnswerId(Long answerId);
+    List<Answer> findByMemberId(Long memberId);
     Answer save(Answer answer);
     Page<Answer> findAllByMemberId(Long memberId, Pageable pageable);
     void delete(Answer answer);

--- a/baebae-BE/src/main/java/com/web/baebaeBE/infra/answer/repository/AnswerRepositoryImpl.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/infra/answer/repository/AnswerRepositoryImpl.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -19,6 +20,11 @@ public class AnswerRepositoryImpl implements AnswerRepository{
         this.jpaRepository = jpaRepository;
     }
 
+
+    @Override
+    public List<Answer> findByMemberId(Long memberId) {
+        return jpaRepository.findByMemberId(memberId);
+    }
     @Override
     public Optional<Answer> findByAnswerId(Long answerId) {
         return jpaRepository.findById(answerId);

--- a/baebae-BE/src/main/java/com/web/baebaeBE/infra/category/entity/Category.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/infra/category/entity/Category.java
@@ -8,6 +8,7 @@ import lombok.*;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -34,8 +35,9 @@ public class Category {
     @Column(name="category_image")
     private String categoryImage;
 
+    @Builder.Default
     @OneToMany(mappedBy = "category")
-    private List<CategorizedAnswer> categoryAnswers;
+    private List<CategorizedAnswer> categoryAnswers = new ArrayList<>();
 
     public void updateCategoryName(String categoryName) {
         this.categoryName = categoryName;

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/answer/AnswerController.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/answer/AnswerController.java
@@ -2,9 +2,11 @@ package com.web.baebaeBE.presentation.answer;
 
 import com.google.firebase.database.annotations.NotNull;
 import com.web.baebaeBE.application.answer.AnswerApplication;
+import com.web.baebaeBE.infra.answer.entity.Answer;
 import com.web.baebaeBE.presentation.answer.api.AnswerApi;
 import com.web.baebaeBE.presentation.answer.dto.AnswerCreateRequest;
 import com.web.baebaeBE.presentation.answer.dto.AnswerDetailResponse;
+import com.web.baebaeBE.presentation.answer.dto.AnswerResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
@@ -31,6 +33,12 @@ public class AnswerController implements AnswerApi {
                                                              @RequestPart AnswerCreateRequest request) {
         AnswerDetailResponse createdAnswer = answerApplication.createAnswer(request, memberId, imageFiles, audioFile);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdAnswer);
+    }
+
+    @GetMapping("/member/{memberId}")
+    public ResponseEntity<List<AnswerResponse>> getAnswersByMemberId(@PathVariable Long memberId) {
+        List<AnswerResponse> answers = answerApplication.getAnswersByMemberId(memberId);
+        return ResponseEntity.ok(answers);
     }
 
     @GetMapping(value = "/{answerId}")

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/answer/AnswerController.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/answer/AnswerController.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class AnswerController implements AnswerApi {
     private final AnswerApplication answerApplication;
 
-    @PostMapping(value = "/member/{memberId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/{memberId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<AnswerDetailResponse> createAnswer(@PathVariable Long memberId,
                                                              @RequestPart(value = "imageFiles") List<MultipartFile> imageFiles,
                                                              @RequestPart(value = "audioFile") MultipartFile audioFile,

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/answer/api/AnswerApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/answer/api/AnswerApi.java
@@ -3,6 +3,7 @@ package com.web.baebaeBE.presentation.answer.api;
 import com.google.firebase.database.annotations.NotNull;
 import com.web.baebaeBE.presentation.answer.dto.AnswerCreateRequest;
 import com.web.baebaeBE.presentation.answer.dto.AnswerDetailResponse;
+import com.web.baebaeBE.presentation.answer.dto.AnswerResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -45,6 +46,22 @@ public interface AnswerApi {
             @RequestPart(value = "audioFile") MultipartFile audioFile,
             @RequestPart(name = "request") AnswerCreateRequest request);
 
+    @Operation(
+            summary = "모든 답변 리스트 조회",
+            description = "해당 회원의 전체 답변을 간략하게 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @Parameter(
+            in = ParameterIn.HEADER,
+            name = "Authorization", required = true,
+            schema = @Schema(type = "string"),
+            description = "Bearer [Access 토큰]")
+    @ApiResponse(responseCode = "200", description = "답변 조회 성공",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = Page.class)))
+    @RequestMapping(method = RequestMethod.GET)
+    ResponseEntity<List<AnswerResponse>> getAnswersByMemberId(
+            @PathVariable Long memberId);
     @Operation(
             summary = "모든 답변 조회",
             description = "모든 답변을 페이지네이션으로 조회합니다.",

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/answer/dto/AnswerResponse.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/answer/dto/AnswerResponse.java
@@ -1,0 +1,21 @@
+package com.web.baebaeBE.presentation.answer.dto;
+
+import com.web.baebaeBE.infra.answer.entity.Answer;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AnswerResponse {
+    private Long id;
+    private String content;
+    private String nickname;
+
+    public static AnswerResponse of(Answer answer) {
+        AnswerResponse response = new AnswerResponse();
+        response.id = answer.getId();
+        response.content = answer.getContent();
+        response.nickname = answer.getMember().getNickname();
+        return response;
+    }
+}

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/category/CategoryController.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/category/CategoryController.java
@@ -6,6 +6,7 @@ import com.web.baebaeBE.presentation.category.api.CategoryApi;
 import com.web.baebaeBE.presentation.category.dto.CategoryRequest;
 import com.web.baebaeBE.presentation.category.dto.CategoryResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -18,12 +19,14 @@ public class CategoryController implements CategoryApi {
 
     private final CategoryApplication categoryApplication;
 
-    @PostMapping(value = "/{memberId}", consumes = {"multipart/form-data"})
+    @PostMapping(value = "/{memberId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CategoryResponse.CategoryInformationResponse> createCategory(
             @PathVariable Long memberId,
             @RequestPart(value = "categoryImage", required = false) MultipartFile categoryImage,
             @RequestPart CategoryRequest.CreateCategory createCategory
     ) {
+        System.out.println("categoryImage: " + categoryImage);
+        System.out.println(createCategory.getCategoryName()+ " " + createCategory.getAnswerIds());
         return ResponseEntity.ok(categoryApplication.createCategory(memberId, categoryImage, createCategory));
     }
 

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/category/dto/CategoryRequest.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/category/dto/CategoryRequest.java
@@ -19,7 +19,7 @@ public class CategoryRequest {
     @AllArgsConstructor
     public static class CreateCategory{
         private String categoryName;
-        private Long answerId;
+        private List<Long> answerIds;
 
     }
 

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/ManageMemberController.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/ManageMemberController.java
@@ -41,6 +41,14 @@ public class ManageMemberController implements ManageMemberApi {
     return manageMemberApplication.getMemberIdByNickname(nickname);
   }
 
+  @GetMapping("/profile-image/{memberId}")
+  public ResponseEntity<ManageMemberResponse.ProfileImageResponse> getProfileImage(
+          @PathVariable Long memberId
+  ) {
+    ManageMemberResponse.ProfileImageResponse profileImageResponse
+            = manageMemberApplication.getProfileImage(memberId);
+    return ResponseEntity.ok(profileImageResponse);
+  }
   @PatchMapping(value = "/profile-image/{memberId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<ManageMemberResponse.ObjectUrlResponse> updateProfileImage(
           @PathVariable Long memberId,

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/api/ManageMemberApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/api/ManageMemberApi.java
@@ -67,7 +67,7 @@ public interface ManageMemberApi {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = Long.class))),
+                            schema = @Schema(implementation = ManageMemberResponse.MemberInformationResponse.class))),
             @ApiResponse(responseCode = "401", description = "토큰 인증 실패",
                     content = @Content(mediaType = "application/json",
                             examples = @ExampleObject(value = "{\n" +
@@ -85,6 +85,34 @@ public interface ManageMemberApi {
     })
     @GetMapping("/members/nickname/{nickname}")
     Long getMemberIdByNickname(@PathVariable String nickname);
+
+    @Operation(
+            summary = "프로필 이미지 조회",
+            description = "인증없이 회원의 프로필 이미지를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ManageMemberResponse.ProfileImageResponse.class))),
+            @ApiResponse(responseCode = "401", description = "토큰 인증 실패",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\n" +
+                                    "  \"errorCode\": \"T-002\",\n" +
+                                    "  \"message\": \"해당 토큰은 유효한 토큰이 아닙니다.\"\n" +
+                                    "}"))
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\n" +
+                                    "  \"errorCode\": \"M-002\",\n" +
+                                    "  \"message\": \"존재하지 않는 회원입니다.\"\n" +
+                                    "}"))
+            )
+    })
+    @GetMapping("/profile-image/{memberId}")
+    ResponseEntity<ManageMemberResponse.ProfileImageResponse> getProfileImage(
+           @PathVariable Long memberId
+    );
 
     @Operation(
             summary = "프로필 사진 업데이트",

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/dto/ManageMemberResponse.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/dto/ManageMemberResponse.java
@@ -48,6 +48,21 @@ public class ManageMemberResponse {
     }
   }
 
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class ProfileImageResponse {
+    private String imageUrl;
+
+    public static ProfileImageResponse of(String imageUrl) {
+      ProfileImageResponse response = new ProfileImageResponse();
+      response.imageUrl = imageUrl;
+      return response;
+    }
+  }
+
 
 
 

--- a/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/dto/ManageMemberResponse.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/presentation/manage/member/dto/ManageMemberResponse.java
@@ -60,8 +60,15 @@ public class ManageMemberResponse {
       ProfileImageResponse response = new ProfileImageResponse();
       response.imageUrl = imageUrl;
       return response;
-      
-      
+    }
+  }
+
+
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class MemberIdResponse{
     private Long memberId;
 


### PR DESCRIPTION
### #️⃣연관된 이슈
> #51

### 📝PR 설명  
기존의 카테고리 생성의 내부 비즈니스로직에 미구현 되어 있었던 로직을 추가 구현하였습니다.
또한 미회원인 사람도 타 사용자의 프로필 이미지는 조회가 가능해야하므로 시큐리티 적용이 안되어 있는 프로필 이미지 조회 API를 추가하였습니다.
마지막으로, 회원 id를 기반으로 해당 회원이 전에 생성했던 피드 전체 리스트를 조회하는 API를 추가하였습니다. 이와 더불어, 기존의 피드 생성 API의 URI를 좀더 의미에 맞게 수정하였습니다.

### 🔨작업 내용
- [x] 카테고리 생성 List 미구현 로직 추가
- [x] 사용자 프로필 이미지 조회 API 추가 (인증X)
- [x] 피드 생성 API URI 수정
- [x] 피드 리스트 조회 API 기능 개발

### 💎결과 (사진 및 작업 결과)
