### PR TITLE
Feature/fcm/#70

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -36,4 +36,4 @@ jobs:
         run: |
           cd baebae-BE
           chmod +x ./gradlew
-          ./gradlew build
+          ./gradlew build --info

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -31,7 +31,7 @@ jobs:
         run: |
           echo "${{ secrets.APPLICATION_YML }}" > baebae-BE/src/main/resources/application.yml
           echo "${{ secrets.APPLICATION_DEPLOY_YML }}" > baebae-BE/src/main/resources/application-deploy.yml
-
+#
       - name: Build with Gradle
         run: |
           cd baebae-BE

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -31,9 +31,9 @@ jobs:
         run: |
           echo "${{ secrets.APPLICATION_YML }}" > baebae-BE/src/main/resources/application.yml
           echo "${{ secrets.APPLICATION_DEPLOY_YML }}" > baebae-BE/src/main/resources/application-deploy.yml
-#
+
       - name: Build with Gradle
         run: |
           cd baebae-BE
           chmod +x ./gradlew
-          ./gradlew build --info
+          ./gradlew build

--- a/baebae-BE/build.gradle
+++ b/baebae-BE/build.gradle
@@ -71,3 +71,13 @@ tasks.named('bootBuildImage') {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+test {
+	testLogging {
+		events "PASSED", "FAILED", "SKIPPED", "STANDARD_OUT", "STANDARD_ERROR"
+		exceptionFormat "full"
+		showCauses true
+		showExceptions true
+		showStackTraces true
+	}
+}

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/controller/FcmController.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/controller/FcmController.java
@@ -1,0 +1,27 @@
+package com.web.baebaeBE.domain.fcm.controller;
+
+
+import com.web.baebaeBE.domain.fcm.dto.FcmRequest;
+import com.web.baebaeBE.domain.fcm.entity.FcmToken;
+import com.web.baebaeBE.domain.fcm.service.FcmService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/fcm")
+public class FcmController {
+
+    private final FcmService fcmService;
+
+
+    @PostMapping("/{memberId}")
+    public ResponseEntity<FcmToken> addFcmToken(
+            @PathVariable Long memberId,
+            @RequestBody FcmRequest.Token request
+    ) {
+        FcmToken token = fcmService.addFcmToken(memberId, request.getFcmToken());
+        return ResponseEntity.ok(token);
+    }
+}

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/controller/FcmController.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/controller/FcmController.java
@@ -1,6 +1,7 @@
 package com.web.baebaeBE.domain.fcm.controller;
 
 
+import com.web.baebaeBE.domain.fcm.controller.api.FcmApi;
 import com.web.baebaeBE.domain.fcm.dto.FcmRequest;
 import com.web.baebaeBE.domain.fcm.entity.FcmToken;
 import com.web.baebaeBE.domain.fcm.service.FcmService;
@@ -11,17 +12,17 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/fcm")
-public class FcmController {
+public class FcmController implements FcmApi {
 
     private final FcmService fcmService;
 
 
     @PostMapping("/{memberId}")
-    public ResponseEntity<FcmToken> addFcmToken(
+    public ResponseEntity<Void> addFcmToken(
             @PathVariable Long memberId,
             @RequestBody FcmRequest.Token request
     ) {
         FcmToken token = fcmService.addFcmToken(memberId, request.getFcmToken());
-        return ResponseEntity.ok(token);
+        return ResponseEntity.ok().build();
     }
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/controller/api/FcmApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/controller/api/FcmApi.java
@@ -8,13 +8,13 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
@@ -22,8 +22,8 @@ import org.springframework.web.bind.annotation.RequestMethod;
 public interface FcmApi {
 
     @Operation(
-            summary = "FCM 토큰 업데이트",
-            description = "회원의 FCM 토큰을 업데이트합니다.",
+            summary = "FCM 토큰 추가",
+            description = "회원의 FCM 토큰을 추가합니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @Parameter(
@@ -49,6 +49,6 @@ public interface FcmApi {
             )
     })
     @RequestMapping(method = RequestMethod.POST, value = "/{memberId}")
-    ResponseEntity<Void> updateFcmToken(@PathVariable Long id,
-                                        @RequestBody FcmRequest.Token requst);
+    ResponseEntity<Void> addFcmToken(@PathVariable Long memberId,
+                                     @RequestBody FcmRequest.Token request);
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/controller/api/FcmApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/controller/api/FcmApi.java
@@ -1,7 +1,7 @@
 package com.web.baebaeBE.domain.fcm.controller.api;
 
 import com.web.baebaeBE.domain.fcm.dto.FcmRequest;
-import com.web.baebaeBE.domain.member.dto.MemberRequest;
+import com.web.baebaeBE.domain.fcm.entity.FcmToken;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/controller/api/FcmApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/controller/api/FcmApi.java
@@ -1,0 +1,54 @@
+package com.web.baebaeBE.domain.fcm.controller.api;
+
+import com.web.baebaeBE.domain.fcm.dto.FcmRequest;
+import com.web.baebaeBE.domain.member.dto.MemberRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@Tag(name = "Fcm", description = "FCM 관련 API")
+public interface FcmApi {
+
+    @Operation(
+            summary = "FCM 토큰 업데이트",
+            description = "회원의 FCM 토큰을 업데이트합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @Parameter(
+            in = ParameterIn.HEADER,
+            name = "Authorization", required = true,
+            schema = @Schema(type = "string"),
+            description = "Bearer [Access 토큰]")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "업데이트 성공"),
+            @ApiResponse(responseCode = "401", description = "토큰 인증 실패",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\n" +
+                                    "  \"errorCode\": \"T-002\",\n" +
+                                    "  \"message\": \"해당 토큰은 유효한 토큰이 아닙니다.\"\n" +
+                                    "}"))
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\n" +
+                                    "  \"errorCode\": \"M-002\",\n" +
+                                    "  \"message\": \"존재하지 않는 회원입니다.\"\n" +
+                                    "}"))
+            )
+    })
+    @RequestMapping(method = RequestMethod.POST, value = "/{memberId}")
+    ResponseEntity<Void> updateFcmToken(@PathVariable Long id,
+                                        @RequestBody FcmRequest.Token requst);
+}

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/dto/FcmRequest.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/dto/FcmRequest.java
@@ -1,0 +1,19 @@
+package com.web.baebaeBE.domain.fcm.dto;
+
+import com.web.baebaeBE.domain.member.entity.MemberType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class FcmRequest {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Token{
+        private String fcmToken;
+    }
+}

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/dto/FcmResponse.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/dto/FcmResponse.java
@@ -1,0 +1,9 @@
+package com.web.baebaeBE.domain.fcm.dto;
+
+import com.web.baebaeBE.domain.member.entity.MemberType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+public class FcmResponse {
+
+}

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/entity/FcmToken.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/entity/FcmToken.java
@@ -21,16 +21,14 @@ public class FcmToken {
     private String token;
 
     @Column(name = "expiration_time", nullable = false)
-    private LocalDateTime expirationTime;
+    private LocalDateTime lastUsedTime;
 
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    // 토큰 만료 여부 확인
-    public boolean isExpired() {
-        return LocalDateTime.now().isAfter(expirationTime);
+    public void updateLastUsedTime() {
+        this.lastUsedTime = LocalDateTime.now();
     }
-
 
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/entity/FcmToken.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/entity/FcmToken.java
@@ -10,7 +10,8 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Setter
+@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class FcmToken {

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/entity/FcmToken.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/entity/FcmToken.java
@@ -3,6 +3,8 @@ package com.web.baebaeBE.domain.fcm.entity;
 import com.web.baebaeBE.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDateTime;
 
@@ -23,8 +25,9 @@ public class FcmToken {
     @Column(name = "expiration_time", nullable = false)
     private LocalDateTime lastUsedTime;
 
-    @ManyToOne(cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     public void updateLastUsedTime() {

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/entity/FcmToken.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/entity/FcmToken.java
@@ -1,0 +1,36 @@
+package com.web.baebaeBE.domain.fcm.entity;
+
+import com.web.baebaeBE.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class FcmToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "fcm_token", nullable = false)
+    private String token;
+
+    @Column(name = "expiration_time", nullable = false)
+    private LocalDateTime expirationTime;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    // 토큰 만료 여부 확인
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expirationTime);
+    }
+
+
+}

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/exception/FcmException.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/exception/FcmException.java
@@ -1,0 +1,18 @@
+package com.web.baebaeBE.domain.fcm.exception;
+
+import com.web.baebaeBE.global.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum FcmException implements ErrorCode {
+
+  NOT_FOUND_FCM(HttpStatus.CONFLICT, "F-001", "FCM 토큰을 찾을 수 없습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String errorCode;
+  private final String message;
+
+}

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/repository/FcmTokenRepository.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/repository/FcmTokenRepository.java
@@ -1,0 +1,11 @@
+package com.web.baebaeBE.domain.fcm.repository;
+
+import com.web.baebaeBE.domain.fcm.entity.FcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+    List<FcmToken> findByMemberId(Long memberId);
+}

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/repository/FcmTokenRepository.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/repository/FcmTokenRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
     List<FcmToken> findByMemberId(Long memberId);
+    Optional<FcmToken> findByToken(String token);
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/service/FcmService.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/service/FcmService.java
@@ -1,6 +1,7 @@
 package com.web.baebaeBE.domain.fcm.service;
 
 import com.web.baebaeBE.domain.fcm.entity.FcmToken;
+import com.web.baebaeBE.domain.fcm.exception.FcmException;
 import com.web.baebaeBE.domain.fcm.repository.FcmTokenRepository;
 import com.web.baebaeBE.domain.member.entity.Member;
 import com.web.baebaeBE.domain.member.exception.MemberException;
@@ -30,9 +31,15 @@ public class FcmService {
         FcmToken token = FcmToken.builder()
                 .token(fcmToken)
                 .member(member)
-                .expirationTime(LocalDateTime.now().plusDays(14))
+                .lastUsedTime(LocalDateTime.now())
                 .build();
 
         return fcmTokenRepository.save(token);
+    }
+
+    // FCM 토큰의 마지막 사용 시간을 현재 시간으로 업데이트
+    public void updateLastUsedTime(FcmToken fcmToken) {
+        fcmToken.updateLastUsedTime();
+        fcmTokenRepository.save(fcmToken);
     }
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/service/FcmService.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/service/FcmService.java
@@ -1,0 +1,38 @@
+package com.web.baebaeBE.domain.fcm.service;
+
+import com.web.baebaeBE.domain.fcm.entity.FcmToken;
+import com.web.baebaeBE.domain.fcm.repository.FcmTokenRepository;
+import com.web.baebaeBE.domain.member.entity.Member;
+import com.web.baebaeBE.domain.member.exception.MemberException;
+import com.web.baebaeBE.domain.member.repository.MemberRepository;
+import com.web.baebaeBE.global.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class FcmService {
+
+    private final MemberRepository memberRepository;
+    private final FcmTokenRepository fcmTokenRepository;
+
+
+    public FcmToken addFcmToken(Long memberId, String fcmToken) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(MemberException.NOT_EXIST_MEMBER));
+
+        FcmToken token = FcmToken.builder()
+                .token(fcmToken)
+                .member(member)
+                .expirationTime(LocalDateTime.now().plusDays(14))
+                .build();
+
+        return fcmTokenRepository.save(token);
+    }
+}

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/service/FcmService.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/fcm/service/FcmService.java
@@ -42,4 +42,12 @@ public class FcmService {
         fcmToken.updateLastUsedTime();
         fcmTokenRepository.save(fcmToken);
     }
+
+    // FCM 토큰 삭제 메서드
+    public void deleteFcmToken(String fcmToken) {
+        FcmToken token = fcmTokenRepository.findByToken(fcmToken)
+                .orElseThrow(() -> new BusinessException(FcmException.NOT_FOUND_FCM));
+
+        fcmTokenRepository.delete(token);
+    }
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/login/controller/LoginController.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/login/controller/LoginController.java
@@ -1,6 +1,7 @@
 package com.web.baebaeBE.domain.login.controller;
 
 
+import com.web.baebaeBE.domain.fcm.service.FcmService;
 import com.web.baebaeBE.domain.login.controller.api.LoginApi;
 import com.web.baebaeBE.domain.login.dto.LoginRequest;
 import com.web.baebaeBE.domain.login.dto.LoginResponse;
@@ -21,6 +22,7 @@ public class LoginController implements LoginApi {
 
   private final LoginService loginService;
   private final ManageTokenService manageTokenService;
+  private final FcmService fcmService;
 
   //로그인
   @PostMapping("/login")
@@ -84,7 +86,10 @@ public class LoginController implements LoginApi {
 
   //로그아웃
   @PostMapping("/logout")
-  public ResponseEntity<Void> logout(HttpServletRequest httpServletRequest) {
+  public ResponseEntity<Void> logout(
+          HttpServletRequest httpServletRequest,
+          @RequestParam String fcmToken
+  ) {
     String authorizationHeader = httpServletRequest.getHeader("Authorization");
     String accessToken = null;
     if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
@@ -93,6 +98,8 @@ public class LoginController implements LoginApi {
 
     //로그아웃 진행
     manageTokenService.logoutMember(accessToken);
+    //fcmToken 삭제
+    fcmService.deleteFcmToken(fcmToken);
 
     return ResponseEntity.ok().build();
   }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/login/controller/api/LoginApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/login/controller/api/LoginApi.java
@@ -145,7 +145,7 @@ public interface LoginApi {
 
     @Operation(
             summary = "로그아웃",
-            description = "Refresh Token 만료시간을 현재시간으로 설정해 로그아웃 시킵니다.",
+            description = "Refresh Token 만료시간을 현재시간으로 설정해 로그아웃 시킵니다. 추가적으로 해당 fcm토큰을 삭제합니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @Parameter(

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/login/controller/api/LoginApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/login/controller/api/LoginApi.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Login", description = "로그인 관련 API")
 public interface LoginApi {
@@ -169,5 +170,5 @@ public interface LoginApi {
                         "}"))
             )
     })
-    ResponseEntity<Void> logout(HttpServletRequest httpServletRequest);
+    ResponseEntity<Void> logout(HttpServletRequest httpServletRequest, @RequestParam String fcmToken);
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/member/controller/MemberController.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/member/controller/MemberController.java
@@ -29,6 +29,7 @@ public class MemberController implements MemberApi {
 
     return ResponseEntity.ok(memberService.getMember(memberId));
   }
+
   @GetMapping("/nickname/{nickname}")
   public ResponseEntity<MemberResponse.MemberIdResponse> getMemberIdByNickname(
           @PathVariable String nickname
@@ -54,14 +55,6 @@ public class MemberController implements MemberApi {
     return ResponseEntity.ok(memberService.updateProfileImage(memberId, image));
   }
 
-  @PatchMapping("/fcm-token/{memberId}")
-  public ResponseEntity<Void> updateFcmToken(
-          @PathVariable Long memberId,
-          @RequestBody MemberRequest.UpdateFcmTokenDto updateFcmTokenDto) {
-
-    memberService.updateFcmToken(memberId, updateFcmTokenDto.getFcmToken());
-    return ResponseEntity.ok().build();
-  }
 
   @PatchMapping("/nickname/{memberId}")
   public ResponseEntity<Void> updateNickname(

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/member/controller/api/MemberApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/member/controller/api/MemberApi.java
@@ -142,37 +142,6 @@ public interface MemberApi {
 
 
 
-    @Operation(
-            summary = "FCM 토큰 업데이트",
-            description = "회원의 FCM 토큰을 업데이트합니다.",
-            security = @SecurityRequirement(name = "bearerAuth")
-    )
-    @Parameter(
-            in = ParameterIn.HEADER,
-            name = "Authorization", required = true,
-            schema = @Schema(type = "string"),
-            description = "Bearer [Access 토큰]")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "업데이트 성공"),
-            @ApiResponse(responseCode = "401", description = "토큰 인증 실패",
-                    content = @Content(mediaType = "application/json",
-                            examples = @ExampleObject(value = "{\n" +
-                                    "  \"errorCode\": \"T-002\",\n" +
-                                    "  \"message\": \"해당 토큰은 유효한 토큰이 아닙니다.\"\n" +
-                                    "}"))
-            ),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원",
-                    content = @Content(mediaType = "application/json",
-                            examples = @ExampleObject(value = "{\n" +
-                                    "  \"errorCode\": \"M-002\",\n" +
-                                    "  \"message\": \"존재하지 않는 회원입니다.\"\n" +
-                                    "}"))
-            )
-    })
-    @RequestMapping(method = RequestMethod.PATCH, value = "/fcm-token/{id}")
-    ResponseEntity<Void> updateFcmToken(@PathVariable Long id,
-                                        @RequestBody MemberRequest.UpdateFcmTokenDto updateFcmTokenDto);
-
 
 
 

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/member/entity/Member.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/member/entity/Member.java
@@ -48,8 +48,6 @@ public class Member implements UserDetails {
   @Column(name = "token_expiration_time")
   private LocalDateTime tokenExpirationTime;
 
-  @Column(name = "fcm_token")
-  private String fcmToken;
 
   @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
   private List<Answer> answers;
@@ -66,11 +64,6 @@ public class Member implements UserDetails {
   public void updateProfileImage(String profileImageKey){
     this.profileImage = profileImageKey;
   }
-  public void updateFcmToken(String fcmToken){
-    this.fcmToken = fcmToken;
-  }
-
-
   public void updateTokenExpirationTime(LocalDateTime time) {
     this.tokenExpirationTime = time;
   }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/member/service/MemberService.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/member/service/MemberService.java
@@ -67,13 +67,6 @@ public class MemberService {
         }
     }
 
-    public void updateFcmToken(Long memberId, String fcmToken) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new BusinessException(LoginException.NOT_EXIST_MEMBER));
-
-        member.updateFcmToken(fcmToken);
-        memberRepository.save(member);
-    }
 
     public void updateNickname(Long memberId, String nickname) {
         Member member = memberRepository.findById(memberId)

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/dto/QuestionDetailResponse.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/dto/QuestionDetailResponse.java
@@ -14,18 +14,16 @@ public class QuestionDetailResponse {
     private Boolean profileOnOff;
     private LocalDateTime createdDate;
     private Boolean isAnswered;
-    private String fcmtoken;
 
-    public QuestionDetailResponse(Long questionId, String content, String nickname, Boolean profileOnOff, LocalDateTime createdDate, String fcmtoken, Boolean isAnswered) {
+    public QuestionDetailResponse(Long questionId, String content, String nickname, Boolean profileOnOff, LocalDateTime createdDate, Boolean isAnswered) {
         this.questionId = questionId;
         this.content = content;
         this.nickname = nickname;
         this.profileOnOff = profileOnOff;
         this.createdDate = createdDate;
-        this.fcmtoken = fcmtoken;
         this.isAnswered = isAnswered;
     }
-    public static QuestionDetailResponse of(Long questionId, String content, String nickname, Boolean profileOnOff, LocalDateTime createdDate, String fcmtoken, Boolean isAnswered) {
-        return new QuestionDetailResponse(questionId, content, nickname, profileOnOff, createdDate, fcmtoken, isAnswered);
+    public static QuestionDetailResponse of(Long questionId, String content, String nickname, Boolean profileOnOff, LocalDateTime createdDate, Boolean isAnswered) {
+        return new QuestionDetailResponse(questionId, content, nickname, profileOnOff, createdDate, isAnswered);
     }
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/repository/QuestionMapper.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/repository/QuestionMapper.java
@@ -23,14 +23,13 @@ public class QuestionMapper {
                 .build();
     }
 
-    public QuestionDetailResponse toDomain(Question question, String fcmtoken) {
+    public QuestionDetailResponse toDomain(Question question) {
         return QuestionDetailResponse.of(
                 question.getId(),
                 question.getContent(),
                 question.getNickname(),
                 question.getProfileOnOff(),
                 question.getCreatedDate(),
-                fcmtoken,
                 question.isAnswered()
         );
     }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/service/QuestionService.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/service/QuestionService.java
@@ -32,16 +32,16 @@ public class QuestionService {
 
         Question question = questionMapper.toEntity(request, member);
         Question savedQuestion = questionRepository.save(question);
-        if (member.getFcmToken() != null) {
-            firebaseNotificationService.notifyNewQuestion(member, question);
-        }
-        return questionMapper.toDomain(savedQuestion, member.getFcmToken());
+
+        firebaseNotificationService.notifyNewQuestion(member, question);// 파이어베이스 메세지 송신
+
+        return questionMapper.toDomain(savedQuestion);
     }
 
     @Transactional(readOnly = true)
     public Page<QuestionDetailResponse> getQuestionsByMemberId(Long memberId, Pageable pageable) {
         Page<Question> questions = questionRepository.findAllByMemberId(memberId, pageable);
-        return questions.map(question -> questionMapper.toDomain(question, question.getMember().getFcmToken()));
+        return questions.map(question -> questionMapper.toDomain(question));
     }
 
     @Transactional
@@ -54,11 +54,9 @@ public class QuestionService {
         // 질문 업데이트 후 저장
         Question updatedQuestion = questionRepository.save(question);
 
-        // FCM 토큰이 있고 질문이 업데이트되었다면 알림 발송
-        if (updatedQuestion.getMember().getFcmToken() != null) {
-            firebaseNotificationService.notifyNewQuestion(updatedQuestion.getMember(), updatedQuestion);
-        }
-        return questionMapper.toDomain(updatedQuestion, updatedQuestion.getMember().getFcmToken());
+        firebaseNotificationService.notifyNewQuestion(updatedQuestion.getMember(), updatedQuestion); // 파이어베이스 메세지 송신
+
+        return questionMapper.toDomain(updatedQuestion);
 
     }
 
@@ -72,12 +70,12 @@ public class QuestionService {
     @Transactional(readOnly = true)
     public Page<QuestionDetailResponse> getAnsweredQuestions(Long memberId, Pageable pageable) {
         Page<Question> questions = questionRepository.findAllByMemberIdAndIsAnsweredTrue(memberId, pageable);
-        return questions.map(question -> questionMapper.toDomain(question, question.getMember().getFcmToken()));
+        return questions.map(question -> questionMapper.toDomain(question));
     }
 
     @Transactional(readOnly = true)
     public Page<QuestionDetailResponse> getUnansweredQuestions(Long memberId, Pageable pageable) {
         Page<Question> questions = questionRepository.findAllByMemberIdAndIsAnsweredFalse(memberId, pageable);
-        return questions.map(question -> questionMapper.toDomain(question, question.getMember().getFcmToken()));
+        return questions.map(question -> questionMapper.toDomain(question));
     }
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/global/converter/MultipartJackson2HttpMessageConverter.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/global/converter/MultipartJackson2HttpMessageConverter.java
@@ -1,4 +1,4 @@
-package com.web.baebaeBE.global.util;
+package com.web.baebaeBE.global.converter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.MediaType;

--- a/baebae-BE/src/main/java/com/web/baebaeBE/global/firebase/FirebaseMessagingService.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/global/firebase/FirebaseMessagingService.java
@@ -17,7 +17,7 @@ public class FirebaseMessagingService {
      * @return        전송된 메시지의 ID
      * @throws FirebaseMessagingException FCM 전송 중 오류 발생 시
      */
-    public String sendNotification(String token, String title, String body) throws FirebaseMessagingException {
+    public String sendNotification(String token, String title, String body) {
         Notification notification = Notification.builder()
                 .setTitle(title)
                 .setBody(body)
@@ -29,6 +29,10 @@ public class FirebaseMessagingService {
                 .build();
 
         // FirebaseMessaging 인스턴스를 통해 메시지 전송
-        return FirebaseMessaging.getInstance().send(message);
+        try {
+            return FirebaseMessaging.getInstance().send(message);
+        } catch (FirebaseMessagingException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/global/firebase/FirebaseNotificationService.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/global/firebase/FirebaseNotificationService.java
@@ -1,52 +1,61 @@
 package com.web.baebaeBE.global.firebase;
 
+import com.web.baebaeBE.domain.fcm.entity.FcmToken;
+import com.web.baebaeBE.domain.fcm.repository.FcmTokenRepository;
 import com.web.baebaeBE.domain.member.entity.Member;
 import com.web.baebaeBE.domain.answer.entity.Answer;
 import com.web.baebaeBE.domain.question.entity.Question;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Service
+@RequiredArgsConstructor
+@Slf4j
 public class FirebaseNotificationService {
     private final FirebaseMessagingService firebaseMessagingService;
+    private final FcmTokenRepository fcmTokenRepository;
 
-    @Autowired
-    public FirebaseNotificationService(FirebaseMessagingService firebaseMessagingService) {
-        this.firebaseMessagingService = firebaseMessagingService;
-    }
 
     public void notifyNewQuestion(Member member, Question question) {
         String notificationTitle = "새 질문이 도착했습니다!";
         String notificationBody = member.getNickname() + "님, 새로운 질문을 확인하세요: " + question.getContent();
-        try {
-            String response = firebaseMessagingService.sendNotification(member.getFcmToken(), notificationTitle, notificationBody);
-            System.out.println("Sent message: " + response);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+
+        // 모든 fcm 토큰 가져오기
+        List<FcmToken> fcmTokens = fcmTokenRepository.findByMemberId(member.getId());
+
+        for (FcmToken fcmToken : fcmTokens)
+            sendNotificationToUser(fcmToken.getToken(), notificationTitle, notificationBody);
     }
-    public void notifyNewAnswer(Member questionMember, Answer answer) {
+    public void notifyNewAnswer(Member member, Answer answer) {
         String notificationTitle = "새로운 답변이 도착했습니다!";
         String notificationBody = "귀하의 질문 \"" + answer.getQuestion().getContent() + "\"에 새로운 답변이 등록되었습니다.";
-        sendNotificationToUser(questionMember.getFcmToken(), notificationTitle, notificationBody);
+
+        // 모든 fcm 토큰 가져오기
+        List<FcmToken> fcmTokens = fcmTokenRepository.findByMemberId(member.getId());
+
+        for (FcmToken fcmToken : fcmTokens)
+            sendNotificationToUser(fcmToken.getToken(), notificationTitle, notificationBody);
     }
 
-    private void sendNotificationToUser(String token, String title, String body) {
-        try {
-            String response = firebaseMessagingService.sendNotification(token, title, body);
-            System.out.println("Sent message: " + response);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
+
     public void notifyReaction(Member member, String content, String reactionType) {
         String notificationTitle = "반응 알림!";
         String notificationBody = member.getNickname() + "님의 답변에 " + reactionType + " 반응이 있습니다: " + content;
-        try {
-            String response = firebaseMessagingService.sendNotification(member.getFcmToken(), notificationTitle, notificationBody);
-            System.out.println("Sent message: " + response);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+
+        // 모든 fcm 토큰 가져오기
+        List<FcmToken> fcmTokens = fcmTokenRepository.findByMemberId(member.getId());
+
+        for (FcmToken fcmToken : fcmTokens)
+            sendNotificationToUser(fcmToken.getToken(), notificationTitle, notificationBody);
+    }
+
+    private void sendNotificationToUser(String token, String title, String body) {
+        String response = firebaseMessagingService.sendNotification(token, title, body);
+        System.out.println("Sent message: " + response);
     }
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/global/firebase/FirebaseNotificationService.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/global/firebase/FirebaseNotificationService.java
@@ -2,6 +2,7 @@ package com.web.baebaeBE.global.firebase;
 
 import com.web.baebaeBE.domain.fcm.entity.FcmToken;
 import com.web.baebaeBE.domain.fcm.repository.FcmTokenRepository;
+import com.web.baebaeBE.domain.fcm.service.FcmService;
 import com.web.baebaeBE.domain.member.entity.Member;
 import com.web.baebaeBE.domain.answer.entity.Answer;
 import com.web.baebaeBE.domain.question.entity.Question;
@@ -9,16 +10,19 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 @Slf4j
 public class FirebaseNotificationService {
     private final FirebaseMessagingService firebaseMessagingService;
     private final FcmTokenRepository fcmTokenRepository;
+    private final FcmService fcmService;
 
 
     public void notifyNewQuestion(Member member, Question question) {
@@ -28,8 +32,10 @@ public class FirebaseNotificationService {
         // 모든 fcm 토큰 가져오기
         List<FcmToken> fcmTokens = fcmTokenRepository.findByMemberId(member.getId());
 
-        for (FcmToken fcmToken : fcmTokens)
+        for (FcmToken fcmToken : fcmTokens) {
             sendNotificationToUser(fcmToken.getToken(), notificationTitle, notificationBody);
+            fcmService.updateLastUsedTime(fcmToken);
+        }
     }
     public void notifyNewAnswer(Member member, Answer answer) {
         String notificationTitle = "새로운 답변이 도착했습니다!";
@@ -38,8 +44,10 @@ public class FirebaseNotificationService {
         // 모든 fcm 토큰 가져오기
         List<FcmToken> fcmTokens = fcmTokenRepository.findByMemberId(member.getId());
 
-        for (FcmToken fcmToken : fcmTokens)
+        for (FcmToken fcmToken : fcmTokens) {
             sendNotificationToUser(fcmToken.getToken(), notificationTitle, notificationBody);
+            fcmService.updateLastUsedTime(fcmToken);
+        }
     }
 
 
@@ -50,8 +58,10 @@ public class FirebaseNotificationService {
         // 모든 fcm 토큰 가져오기
         List<FcmToken> fcmTokens = fcmTokenRepository.findByMemberId(member.getId());
 
-        for (FcmToken fcmToken : fcmTokens)
+        for (FcmToken fcmToken : fcmTokens) {
             sendNotificationToUser(fcmToken.getToken(), notificationTitle, notificationBody);
+            fcmService.updateLastUsedTime(fcmToken);
+        }
     }
 
     private void sendNotificationToUser(String token, String title, String body) {

--- a/baebae-BE/src/main/java/com/web/baebaeBE/global/scheduler/FcmTokenSchduler.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/global/scheduler/FcmTokenSchduler.java
@@ -1,0 +1,33 @@
+package com.web.baebaeBE.global.scheduler;
+
+import com.web.baebaeBE.domain.fcm.entity.FcmToken;
+import com.web.baebaeBE.domain.fcm.repository.FcmTokenRepository;
+import com.web.baebaeBE.domain.fcm.service.FcmService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component // 스프링 빈으로 등록
+@RequiredArgsConstructor // final 필드나 @NonNull 필드에 대한 생성자를 자동으로 생성
+public class FcmTokenSchduler {
+    private final FcmTokenRepository fcmTokenRepository; // FcmTokenRepository 주입
+
+    // 매일 자정에 실행되는 스케줄러
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void deleteUnusedTokens() {
+        // 한 달 전 시간 계산
+        LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
+
+        // 모든 FcmToken 조회
+        List<FcmToken> tokens = fcmTokenRepository.findAll();
+        for (FcmToken token : tokens) {
+            // 마지막 사용 시간이 한 달 이상 지난 토큰 삭제
+            if (token.getLastUsedTime().isBefore(oneMonthAgo)) {
+                fcmTokenRepository.delete(token);
+            }
+        }
+    }
+}

--- a/baebae-BE/src/test/java/com/web/baebaeBE/integration/manage/member/ManageMemberTest.java
+++ b/baebae-BE/src/test/java/com/web/baebaeBE/integration/manage/member/ManageMemberTest.java
@@ -1,6 +1,7 @@
 package com.web.baebaeBE.integration.manage.member;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.web.baebaeBE.domain.fcm.dto.FcmRequest;
 import com.web.baebaeBE.global.jwt.JwtTokenProvider;
 import com.web.baebaeBE.domain.member.entity.Member;
 import com.web.baebaeBE.domain.member.entity.MemberType;
@@ -127,18 +128,17 @@ public class ManageMemberTest {
     }
 
     @Test
-    @DisplayName("FCM 토큰 업데이트 테스트(): 해당 회원의 FCM 토큰을 업데이트한다.")
-    public void updateFcmTokenTest() throws Exception {
+    @DisplayName("FCM 토큰 추가 테스트(): 해당 회원에게 FCM 토큰을 추가한다.")
+    public void addFcmTokenTest() throws Exception {
         // given
-        MemberRequest.UpdateFcmTokenDto updateFcmTokenDto
-                = new MemberRequest.UpdateFcmTokenDto("fwef094938jweSIJDe8204gaskd390GK32G9HADF0809d8708U908ud9UHD9FH4e32982hF0ODH22E");
+        FcmRequest.Token tokenRequest = new FcmRequest.Token("fwef094938jweSIJDe8204gaskd390GK32G9HADF0809d8708U908ud9UHD9FH4e32982hF0ODH22E");
 
         // when
-        mockMvc.perform(patch("/api/member/fcm-token/{memberId}", testMember.getId())
+        mockMvc.perform(post("/api/fcm/{memberId}", testMember.getId())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(updateFcmTokenDto))
+                        .content(objectMapper.writeValueAsString(tokenRequest))
                         .header("Authorization", "Bearer " + accessToken))
-        // then
+                // then
                 .andExpect(status().isOk());
     }
 


### PR DESCRIPTION
### #️⃣연관된 이슈
> #70 

### 📝PR 설명
Member 테이블과 FcmToken 테이블 분리작업을 진행하였습니다. 변경된로직은 다음과 같습니다.
- 한 사용자가 여러기기를 사용할때 FCM 토큰을 여러개 생성할 수 있다.
- 한 사용자가 로그아웃할 때, 해당 FCM 토큰을 삭제한다.
- FCM 토큰을 신선도관리를 진행한다. 이때, 마지막 사용시간을 기준으로하며, 1달이 넘을경우 자동삭제한다.
- FCM 토큰은 사용자에게 다시 반환하지 않는다.

### 🔨작업 내용
- [x] FCM 테이블 분리
- [x] FCM 토큰 신선도관리 기능 추가
- [x] FCM 토큰 자동삭제 스케줄러 추가
- [x] 로그아웃시 FCM 토큰 삭제 로직 추가
- [x] FCM 토큰 추가 API 개발
- [x] FCM 토큰 테스트 리팩토링

### 💎결과 (사진 및 작업 결과)
