### PR TITLE
fix: imageUrl, 답변되지 않은 질문개수 조회 추가

### DIFF
--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/controller/AnswerController.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/controller/AnswerController.java
@@ -68,14 +68,6 @@ public class AnswerController implements AnswerApi {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
     }
 
-    @PatchMapping("/{answerId}/react")
-    public ResponseEntity<Void> updateAnswerReactions(@PathVariable Long answerId,
-                                                      @RequestParam int heartCount,
-                                                      @RequestParam int curiousCount,
-                                                      @RequestParam int sadCount) {
-        answerService.updateReactionCounts(answerId, heartCount, curiousCount, sadCount);
-        return ResponseEntity.ok().build();
-    }
 
     @GetMapping("/{answerId}/reacted")
     public ResponseEntity<Boolean> hasReacted(@PathVariable Long answerId,

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/controller/api/AnswerApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/controller/api/AnswerApi.java
@@ -27,7 +27,7 @@ public interface AnswerApi {
 
     @Operation(
             summary = "답변 생성",
-            description = "새로운 답변을 생성합니다. 이미지 파일과 오디오 파일을 포함할 수 있습니다.",
+            description = "새로운 답변을 생성합니다. 이미지 파일을 포함합니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @Parameter(
@@ -62,8 +62,8 @@ public interface AnswerApi {
             @PathVariable Long memberId);
     @Operation(
             summary = "모든 답변 조회",
-            description = "모든 답변을 페이지네이션으로 조회합니다.",
-            security = @SecurityRequirement(name = "bearerAuth")
+            description = "모든 답변을 페이지네이션으로 조회합니다."
+
     )
     @Parameter(
             in = ParameterIn.HEADER,
@@ -112,23 +112,6 @@ public interface AnswerApi {
     ResponseEntity<Void> deleteAnswer(
             @PathVariable Long answerId);
 
-    @Operation(
-            summary = "답변에 반응 업데이트",
-            description = "특정 답변에 대해 반응(좋아요, 궁금해요, 슬퍼요)을 업데이트합니다.",
-            security = @SecurityRequirement(name = "bearerAuth")
-    )
-    @Parameter(
-            in = ParameterIn.HEADER,
-            name = "Authorization", required = true,
-            schema = @Schema(type = "string"),
-            description = "Bearer [Access 토큰]")
-    @ApiResponse(responseCode = "200", description = "반응 업데이트 성공")
-    @PatchMapping("/{answerId}/react")
-    ResponseEntity<Void> updateAnswerReactions(
-            @PathVariable Long answerId,
-            @RequestParam int heartCount,
-            @RequestParam int curiousCount,
-            @RequestParam int sadCount);
 
     @Operation(
             summary = "특정 답변에 대한 사용자의 반응 여부 확인",

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/dto/AnswerCreateRequest.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/dto/AnswerCreateRequest.java
@@ -16,10 +16,11 @@ public class AnswerCreateRequest {
     private String musicName;
     private String musicSinger;
     private String musicAudioUrl;
+    private String imageUrl;
 
     public AnswerCreateRequest(Long questionId, String content,String nickname,
                                Boolean profileOnOff, String linkAttachments,
-                               String musicName, String musicSinger, String musicAudioUrl) {
+                               String musicName, String musicSinger, String musicAudioUrl, String imageUrl) {
         this.questionId = questionId;
         this.content = content;
         this.nickname = nickname;
@@ -28,12 +29,13 @@ public class AnswerCreateRequest {
         this.musicName = musicName;
         this.musicSinger = musicSinger;
         this.musicAudioUrl = musicAudioUrl;
+        this.imageUrl = imageUrl;
     }
 
     public static AnswerCreateRequest of(Long questionId, String content, String  nickname,
                                          Boolean profileOnOff, String linkAttachments,
-                                         String musicName, String musicSinger, String musicAudioUrl) {
+                                         String musicName, String musicSinger, String musicAudioUrl, String imageUrl) {
         return new AnswerCreateRequest(questionId, content, nickname, profileOnOff, linkAttachments,
-                musicName, musicSinger, musicAudioUrl);
+                musicName, musicSinger, musicAudioUrl, imageUrl);
     }
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/dto/AnswerDetailResponse.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/dto/AnswerDetailResponse.java
@@ -21,6 +21,7 @@ public class AnswerDetailResponse {
     private String musicName;
     private String musicSinger;
     private String musicAudioUrl;
+    private String imageUrl;
     private LocalDateTime createdDate;
     private Integer heartCount;
     private Integer curiousCount;
@@ -29,7 +30,7 @@ public class AnswerDetailResponse {
     public AnswerDetailResponse(Long answerId, Long questionId, String questionContent, Long memberId,
                                 String content, String memberNickname, String nickname, Boolean profileOnOff,
                                 String linkAttachments, String musicName, String musicSinger, String musicAudioUrl,
-                                 LocalDateTime createdDate,
+                                 String imageUrl, LocalDateTime createdDate,
                                 Integer heartCount, Integer curiousCount, Integer sadCount) {
         this.answerId = answerId;
         this.questionId = questionId;
@@ -43,6 +44,7 @@ public class AnswerDetailResponse {
         this.musicName = musicName;
         this.musicSinger = musicSinger;
         this.musicAudioUrl = musicAudioUrl;
+        this.imageUrl = imageUrl;
         this.createdDate = createdDate;
         this.heartCount = heartCount;
         this.curiousCount = curiousCount;
@@ -52,10 +54,10 @@ public class AnswerDetailResponse {
     public static AnswerDetailResponse of(Long answerId, Long questionId, String questionContent, Long memberId,
                                           String content, String memberNickname, String nickname, Boolean profileOnOff,
                                           String linkAttachments, String musicName, String musicSinger, String musicAudioUrl,
-                                           LocalDateTime createdDate,
+                                          String imageUrl, LocalDateTime createdDate,
                                           Integer heartCount, Integer curiousCount, Integer sadCount) {
         return new AnswerDetailResponse(answerId, questionId, questionContent, memberId, content, memberNickname,
-                nickname, profileOnOff, linkAttachments, musicName, musicSinger, musicAudioUrl, createdDate,
+                nickname, profileOnOff, linkAttachments, musicName, musicSinger, musicAudioUrl, imageUrl, createdDate,
                 heartCount, curiousCount, sadCount);
 
     }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/entity/Answer.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/entity/Answer.java
@@ -59,6 +59,9 @@ public class Answer {
     @Column(name = "link_attachment")
     private String linkAttachments;
 
+    @Column(name = "image_url")
+    private String imageUrl;
+
     @Column(name = "heart_count", nullable = false)
     private int heartCount;
 
@@ -78,11 +81,11 @@ public class Answer {
     private boolean profileOnOff;
 
     public static Answer of(Long id, Question question, Category category, Member member, String nickname,String content,
-                            List<String> imageFiles, Music music, String linkAttachments, int heartCount,
+                            List<String> imageFiles, Music music, String linkAttachments, String  imageUrl, int heartCount,
                             int curiousCount, int sadCount, LocalDateTime createdDate, boolean profileOnOff) {
 
-        return new Answer(id, question, category, member, nickname, imageFiles, content, music, linkAttachments, heartCount,
-                curiousCount, sadCount, createdDate,null, profileOnOff);
+        return new Answer(id, question, category, member, nickname, imageFiles, content, music, linkAttachments,imageUrl, heartCount,
+                 curiousCount, sadCount, createdDate,null, profileOnOff);
     }
 
     public void increaseReactionCount(ReactionValue reaction) {

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/repository/AnswerMapper.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/repository/AnswerMapper.java
@@ -11,6 +11,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Component
 @AllArgsConstructor
@@ -48,6 +49,8 @@ public class AnswerMapper {
         Music music = answer.getMusic();
         Member member = answer.getMember();
         Question question = answer.getQuestion();
+        List<String> imageFiles = answer.getImageFiles();
+        String imageUrl = (imageFiles != null && !imageFiles.isEmpty()) ? imageFiles.get(0) : null;
         return AnswerDetailResponse.of(
                 answer.getId(),
                 question.getId(),
@@ -61,6 +64,7 @@ public class AnswerMapper {
                 music != null ? music.getMusicName() : null,
                 music != null ? music.getMusicSinger() : null,
                 music != null ? music.getMusicAudioUrl() : null,
+                imageUrl,
                 answer.getCreatedDate(),
                 answer.getHeartCount(),
                 answer.getCuriousCount(),

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/category/controller/api/CategoryApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/category/controller/api/CategoryApi.java
@@ -43,8 +43,8 @@ public interface CategoryApi {
 
 
     @Operation(summary = "멤버의 모든 카테고리 조회",
-            description = "멤버 ID를 받아 해당 멤버의 모든 카테고리를 조회합니다.",
-            security = @SecurityRequirement(name = "bearerAuth")
+            description = "멤버 ID를 받아 해당 멤버의 모든 카테고리를 조회합니다."
+
     )
     @Parameter(
             in = ParameterIn.HEADER,

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/controller/QuestionController.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/controller/QuestionController.java
@@ -62,9 +62,9 @@ public class QuestionController implements QuestionApi {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
     }
 
-    @GetMapping("/count/{memberId}")
-    public ResponseEntity<Long> countQuestionsByMemberId(@PathVariable Long memberId) {
-        long count = questionService.countQuestionsByMemberId(memberId);
+    @GetMapping("/unanswered/count/{memberId}")
+    public ResponseEntity<Long> getUnansweredQuestionCount(@PathVariable Long memberId) {
+        long count = questionService.getUnansweredQuestionCount(memberId);
         return ResponseEntity.ok(count);
     }
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/controller/api/QuestionApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/controller/api/QuestionApi.java
@@ -98,15 +98,15 @@ public interface QuestionApi {
     @ApiResponse(responseCode = "204", description = "질문 삭제 성공")
     @DeleteMapping("/{questionId}")
     ResponseEntity<Void> deleteQuestion(@PathVariable Long questionId);
-
     @Operation(
-            summary = "질문 개수 조회",
-            description = "특정 회원이 받은 모든 질문의 개수를 조회합니다.",
+            summary = "답변되지 않은 질문 개수 조회",
+            description = "특정 회원의 답변되지 않은 질문의 개수를 조회합니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
-    @ApiResponse(responseCode = "200", description = "질문 개수 조회 성공",
+    @ApiResponse(responseCode = "200", description = "답변되지 않은 질문 개수 조회 성공",
             content = @Content(mediaType = "application/json",
                     schema = @Schema(implementation = Long.class)))
-    @GetMapping("/count/{memberId}")
-    ResponseEntity<Long> countQuestionsByMemberId(@PathVariable Long memberId);
+    @GetMapping("/unanswered/count/{memberId}")
+    ResponseEntity<Long> getUnansweredQuestionCount(@PathVariable Long memberId);
+
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/repository/QuestionJpaRepository.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/repository/QuestionJpaRepository.java
@@ -9,6 +9,5 @@ public interface QuestionJpaRepository extends JpaRepository<Question, Long> {
     Page<Question> findAllByMemberId(Long memberId, Pageable pageable);
     Page<Question> findAllByMemberIdAndIsAnsweredTrue(Long memberId, Pageable pageable);
     Page<Question> findAllByMemberIdAndIsAnsweredFalse(Long memberId, Pageable pageable);
-    Long countByMemberId(Long memberId);
-
+    long countByMemberIdAndIsAnsweredFalse(Long memberId);
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/repository/QuestionRepository.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/repository/QuestionRepository.java
@@ -14,6 +14,5 @@ public interface QuestionRepository{
     Page<Question> findAllByMemberIdAndIsAnsweredTrue(Long memberId, Pageable pageable);
     Page<Question> findAllByMemberIdAndIsAnsweredFalse(Long memberId, Pageable pageable);
     void delete(Question questionEntity);
-    Long countByMemberId(Long memberId);
-
+    long countByMemberIdAndIsAnsweredFalse(Long memberId);
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/repository/QuestionRepositoryImpl.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/repository/QuestionRepositoryImpl.java
@@ -48,7 +48,8 @@ public class QuestionRepositoryImpl implements QuestionRepository {
     }
 
     @Override
-    public Long countByMemberId(Long memberId) {
-        return questionJpaRepository.countByMemberId(memberId);
+    public long countByMemberIdAndIsAnsweredFalse(Long memberId) {
+        return questionJpaRepository.countByMemberIdAndIsAnsweredFalse(memberId);
     }
+
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/service/QuestionService.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/service/QuestionService.java
@@ -80,7 +80,8 @@ public class QuestionService {
     }
 
     @Transactional(readOnly = true)
-    public long countQuestionsByMemberId(Long memberId) {
-        return questionRepository.countByMemberId(memberId);
+    public long getUnansweredQuestionCount(Long memberId) {
+        return questionRepository.countByMemberIdAndIsAnsweredFalse(memberId);
     }
+
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
> #39 

### 📝PR 설명
프론트 요청사항으로 삭제되었던 imageUrl을 추가하였습니다. 
이외에도 답변되지 않은 질문 전체 개수 조회가 가능하게 하였습니다. 
또한, authorization을 전체피드조회, 전체 카테고리 조회에서 제거하여 모든 사용자가 볼 수 있게 수정하였습니다.

### 🔨작업 내용
- [ ] imageUrl 추가
- [ ] 답변 되지 않은 질문 개수 조회
- [ ]  전체피드 조회, 전체 카테고리 조회에서 보안 제거

### 💎결과 (사진 및 작업 결과)
