### PR TITLE
feat: 특정 답변 반응개수 확인 api 추가, 답변 수정시 이미지 파일 선택가능

### DIFF
--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/controller/AnswerController.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/controller/AnswerController.java
@@ -5,11 +5,9 @@ import com.web.baebaeBE.domain.answer.dto.AnswerCreateRequest;
 import com.web.baebaeBE.domain.answer.dto.AnswerDetailResponse;
 import com.web.baebaeBE.domain.answer.dto.AnswerResponse;
 import com.web.baebaeBE.domain.answer.service.AnswerService;
-import com.web.baebaeBE.domain.categorized.answer.service.CategorizedAnswerService;
 
-import com.web.baebaeBE.domain.category.service.CategoryService;
+import com.web.baebaeBE.domain.reaction.dto.ReactionResponse;
 import com.web.baebaeBE.domain.reaction.entity.ReactionValue;
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,7 +26,6 @@ import java.util.Map;
 public class AnswerController implements AnswerApi {
     private final AnswerService answerService;
 
-    private final CategorizedAnswerService categorizedAnswerService;
     @PostMapping(value = "/{memberId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<AnswerDetailResponse> createAnswer(@PathVariable Long memberId,
                                                              @RequestPart(value = "imageFile") MultipartFile imageFile,
@@ -46,18 +43,15 @@ public class AnswerController implements AnswerApi {
     @GetMapping()
     public ResponseEntity<Page<AnswerDetailResponse>> getAllAnswers(
             @RequestParam Long memberId,
-            @RequestParam(required = false) Long categoryId, // Change this from Category to Long
+            @RequestParam(required = false) Long categoryId,
             Pageable pageable) {
 
-
         return ResponseEntity.ok(answerService.getAllAnswers(memberId, categoryId, pageable));
-
-
     }
 
     @PutMapping(value = "/{answerId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<AnswerDetailResponse> updateAnswer(@PathVariable Long answerId,
-                                                             @RequestPart(value = "imageFile") MultipartFile imageFile,
+                                                             @RequestPart(value = "imageFile", required = false) MultipartFile imageFile,
                                                              @RequestPart AnswerCreateRequest request) {
         AnswerDetailResponse updatedAnswer = answerService.updateAnswer(answerId, request, imageFile);
         return ResponseEntity.ok(updatedAnswer);
@@ -74,5 +68,11 @@ public class AnswerController implements AnswerApi {
                                                                   @RequestParam Long memberId) {
         Map<ReactionValue, Boolean> hasReacted = answerService.hasReacted(answerId, memberId);
         return ResponseEntity.ok(hasReacted);
+    }
+
+    @GetMapping("/{answerId}/reactionsCount")
+    public ResponseEntity<ReactionResponse.CountReactionInformationDto> getReactionCounts(@PathVariable Long answerId) {
+        ReactionResponse.CountReactionInformationDto reactionCounts = answerService.getReactionCounts(answerId);
+        return ResponseEntity.ok(reactionCounts);
     }
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/controller/api/AnswerApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/controller/api/AnswerApi.java
@@ -3,6 +3,7 @@ package com.web.baebaeBE.domain.answer.controller.api;
 import com.web.baebaeBE.domain.answer.dto.AnswerCreateRequest;
 import com.web.baebaeBE.domain.answer.dto.AnswerDetailResponse;
 import com.web.baebaeBE.domain.answer.dto.AnswerResponse;
+import com.web.baebaeBE.domain.reaction.dto.ReactionResponse;
 import com.web.baebaeBE.domain.reaction.entity.ReactionValue;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -47,8 +48,7 @@ public interface AnswerApi {
 
     @Operation(
             summary = "모든 답변 리스트 조회",
-            description = "해당 회원의 전체 답변을 간략하게 조회합니다.",
-            security = @SecurityRequirement(name = "bearerAuth")
+            description = "해당 회원의 전체 답변을 간략하게 조회합니다."
     )
     @Parameter(
             in = ParameterIn.HEADER,
@@ -64,17 +64,11 @@ public interface AnswerApi {
     @Operation(
             summary = "모든 답변 조회",
             description = "모든 답변을 페이지네이션으로 조회합니다."
-
     )
-    @Parameter(
-            in = ParameterIn.HEADER,
-            name = "Authorization", required = true,
-            schema = @Schema(type = "string"),
-            description = "Bearer [Access 토큰]")
     @ApiResponse(responseCode = "200", description = "답변 조회 성공",
             content = @Content(mediaType = "application/json",
                     schema = @Schema(implementation = Page.class)))
-    @RequestMapping(method = RequestMethod.GET)
+    @GetMapping
     ResponseEntity<Page<AnswerDetailResponse>> getAllAnswers(
             @RequestParam Long memberId,
             @RequestParam(required = false) Long category,
@@ -95,8 +89,8 @@ public interface AnswerApi {
     @PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResponseEntity<AnswerDetailResponse> updateAnswer(
             @PathVariable Long answerId,
-            @RequestPart(value = "imageFiles") MultipartFile imageFiles,
-            @RequestPart(name = "request") AnswerCreateRequest request);
+            @RequestPart(value = "imageFile", required = false) MultipartFile imageFile,
+            @RequestPart AnswerCreateRequest request);
 
     @Operation(
             summary = "답변 삭제",
@@ -131,5 +125,17 @@ public interface AnswerApi {
     ResponseEntity<Map<ReactionValue, Boolean>> hasReacted(
             @PathVariable Long answerId,
             @RequestParam Long memberId);
+
+    @Operation(
+            summary = "특정 답변의 반응 개수 조회",
+            description = "특정 답변에 대한 하트, 궁금해요, 슬퍼요 반응의 개수를 조회합니다."
+    )
+
+    @ApiResponse(responseCode = "200", description = "반응 개수 조회 성공",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ReactionResponse.CountReactionInformationDto.class)))
+    @GetMapping("/{answerId}/reactionsCount")
+    ResponseEntity<ReactionResponse.CountReactionInformationDto> getReactionCounts(
+            @PathVariable Long answerId);
 
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/controller/api/AnswerApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/controller/api/AnswerApi.java
@@ -128,7 +128,7 @@ public interface AnswerApi {
 
     @Operation(
             summary = "특정 답변의 반응 개수 조회",
-            description = "특정 답변에 대한 하트, 궁금해요, 슬퍼요 반응의 개수를 조회합니다."
+            description = "특정 답변에 대한 하트, 궁금해요, 슬퍼요, 통했당 반응의 개수를 조회합니다."
     )
 
     @ApiResponse(responseCode = "200", description = "반응 개수 조회 성공",

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/dto/AnswerCreateRequest.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/dto/AnswerCreateRequest.java
@@ -2,7 +2,6 @@ package com.web.baebaeBE.domain.answer.dto;
 
 import lombok.*;
 
-import java.util.List;
 
 @Getter
 @Setter
@@ -17,10 +16,13 @@ public class AnswerCreateRequest {
     private String musicSinger;
     private String musicAudioUrl;
     private String imageUrl;
+    private boolean updateImage;
+
+
 
     public AnswerCreateRequest(Long questionId, String content,String nickname,
                                Boolean profileOnOff, String linkAttachments,
-                               String musicName, String musicSinger, String musicAudioUrl, String imageUrl) {
+                               String musicName, String musicSinger, String musicAudioUrl, String imageUrl, boolean updateImage) {
         this.questionId = questionId;
         this.content = content;
         this.nickname = nickname;
@@ -30,12 +32,14 @@ public class AnswerCreateRequest {
         this.musicSinger = musicSinger;
         this.musicAudioUrl = musicAudioUrl;
         this.imageUrl = imageUrl;
+        this.updateImage = updateImage;
+
     }
 
     public static AnswerCreateRequest of(Long questionId, String content, String  nickname,
                                          Boolean profileOnOff, String linkAttachments,
-                                         String musicName, String musicSinger, String musicAudioUrl, String imageUrl) {
+                                         String musicName, String musicSinger, String musicAudioUrl, String imageUrl, boolean updateImage) {
         return new AnswerCreateRequest(questionId, content, nickname, profileOnOff, linkAttachments,
-                musicName, musicSinger, musicAudioUrl, imageUrl);
+                musicName, musicSinger, musicAudioUrl, imageUrl, updateImage);
     }
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/dto/AnswerDetailResponse.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/dto/AnswerDetailResponse.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Getter
 @Setter
@@ -23,15 +22,11 @@ public class AnswerDetailResponse {
     private String musicAudioUrl;
     private String imageUrl;
     private LocalDateTime createdDate;
-    private Integer heartCount;
-    private Integer curiousCount;
-    private Integer sadCount;
 
     public AnswerDetailResponse(Long answerId, Long questionId, String questionContent, Long memberId,
                                 String content, String memberNickname, String nickname, Boolean profileOnOff,
                                 String linkAttachments, String musicName, String musicSinger, String musicAudioUrl,
-                                 String imageUrl, LocalDateTime createdDate,
-                                Integer heartCount, Integer curiousCount, Integer sadCount) {
+                                 String imageUrl, LocalDateTime createdDate) {
         this.answerId = answerId;
         this.questionId = questionId;
         this.questionContent = questionContent;
@@ -46,19 +41,14 @@ public class AnswerDetailResponse {
         this.musicAudioUrl = musicAudioUrl;
         this.imageUrl = imageUrl;
         this.createdDate = createdDate;
-        this.heartCount = heartCount;
-        this.curiousCount = curiousCount;
-        this.sadCount = sadCount;
     }
 
     public static AnswerDetailResponse of(Long answerId, Long questionId, String questionContent, Long memberId,
                                           String content, String memberNickname, String nickname, Boolean profileOnOff,
                                           String linkAttachments, String musicName, String musicSinger, String musicAudioUrl,
-                                          String imageUrl, LocalDateTime createdDate,
-                                          Integer heartCount, Integer curiousCount, Integer sadCount) {
+                                          String imageUrl, LocalDateTime createdDate) {
         return new AnswerDetailResponse(answerId, questionId, questionContent, memberId, content, memberNickname,
-                nickname, profileOnOff, linkAttachments, musicName, musicSinger, musicAudioUrl, imageUrl, createdDate,
-                heartCount, curiousCount, sadCount);
+                nickname, profileOnOff, linkAttachments, musicName, musicSinger, musicAudioUrl, imageUrl, createdDate);
 
     }
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/entity/Answer.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/entity/Answer.java
@@ -71,6 +71,9 @@ public class Answer {
     @Column(name = "sad_count", nullable = false)
     private int sadCount;
 
+    @Column(name = "connect_count", nullable = false)
+    private int connectCount;
+
     @Column(name = "created_date", nullable = false)
     private LocalDateTime createdDate;
 
@@ -82,10 +85,10 @@ public class Answer {
 
     public static Answer of(Long id, Question question, Category category, Member member, String nickname,String content,
                             List<String> imageFiles, Music music, String linkAttachments, String  imageUrl, int heartCount,
-                            int curiousCount, int sadCount, LocalDateTime createdDate, boolean profileOnOff) {
+                            int curiousCount, int sadCount, int connectCount, LocalDateTime createdDate, boolean profileOnOff) {
 
         return new Answer(id, question, category, member, nickname, imageFiles, content, music, linkAttachments,imageUrl, heartCount,
-                 curiousCount, sadCount, createdDate,null, profileOnOff);
+                 curiousCount, sadCount, connectCount, createdDate,null, profileOnOff);
     }
 
     public void increaseReactionCount(ReactionValue reaction) {

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/repository/AnswerMapper.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/repository/AnswerMapper.java
@@ -7,7 +7,6 @@ import com.web.baebaeBE.domain.music.entity.Music;
 import com.web.baebaeBE.domain.question.entity.Question;
 import com.web.baebaeBE.domain.answer.dto.AnswerCreateRequest;
 import com.web.baebaeBE.domain.answer.dto.AnswerDetailResponse;
-import com.web.baebaeBE.domain.reaction.repository.MemberAnswerReactionRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -17,7 +16,6 @@ import java.util.List;
 @Component
 @AllArgsConstructor
 public class AnswerMapper {
-    private final MemberAnswerReactionRepository memberAnswerReactionRepository;
     public Answer toEntity(AnswerCreateRequest request, Question question, Member member) {
         // Music 엔티티 생성
         Music music = Music.builder()
@@ -60,18 +58,15 @@ public class AnswerMapper {
                 question.getContent(),
                 member.getId(),
                 answer.getContent(),
-                member.getNickname(),              // 실제 닉네임
-                answer.getNickname(),              // 익명 닉네임
-                answer.isProfileOnOff(),           // 프로필 공개 여부
+                member.getNickname(),
+                answer.getNickname(),
+                answer.isProfileOnOff(),
                 answer.getLinkAttachments(),
                 music != null ? music.getMusicName() : null,
                 music != null ? music.getMusicSinger() : null,
                 music != null ? music.getMusicAudioUrl() : null,
                 imageUrl,
-                answer.getCreatedDate(),
-                answer.getHeartCount(),
-                answer.getCuriousCount(),
-                answer.getSadCount()
+                answer.getCreatedDate()
         );
     }
 

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/repository/AnswerMapper.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/repository/AnswerMapper.java
@@ -36,6 +36,7 @@ public class AnswerMapper {
                 .heartCount(0)
                 .curiousCount(0)
                 .sadCount(0)
+                .connectCount(0)
                 .music(music)
                 .build();
 

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/service/AnswerService.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/service/AnswerService.java
@@ -12,6 +12,7 @@ import com.web.baebaeBE.domain.member.repository.MemberRepository;
 import com.web.baebaeBE.domain.notification.dto.NotificationRequest;
 import com.web.baebaeBE.domain.notification.service.NotificationService;
 import com.web.baebaeBE.domain.question.repository.QuestionRepository;
+import com.web.baebaeBE.domain.reaction.dto.ReactionResponse;
 import com.web.baebaeBE.domain.reaction.entity.ReactionValue;
 import com.web.baebaeBE.domain.reaction.repository.MemberAnswerReactionRepository;
 import com.web.baebaeBE.global.error.exception.BusinessException;
@@ -112,7 +113,7 @@ public class AnswerService {
         answer.getMusic().setMusicSinger(request.getMusicSinger());
         answer.getMusic().setMusicAudioUrl(request.getMusicAudioUrl());
 
-        if (!imageFile.isEmpty()) {
+        if (request.isUpdateImage() && imageFile != null && !imageFile.isEmpty()) {
             try (InputStream inputStream = imageFile.getInputStream()) {
                 String imageUrl = s3ImageStorageService.uploadFile(answer.getMember().getId().toString(), answerId.toString(), "image", 0, inputStream, imageFile.getSize(), imageFile.getContentType());
                 answer.setImageFiles(List.of(imageUrl));
@@ -170,5 +171,13 @@ public class AnswerService {
             reactionStatus.put(reactionValue, hasReacted);
         }
         return reactionStatus;
+    }
+
+    @Transactional
+    public ReactionResponse.CountReactionInformationDto getReactionCounts(Long answerId) {
+        Answer answer = answerRepository.findByAnswerId(answerId)
+                .orElseThrow(() -> new BusinessException(AnswerError.NO_EXIST_ANSWER));
+
+        return ReactionResponse.CountReactionInformationDto.of(answer);
     }
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/category/controller/api/CategoryApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/category/controller/api/CategoryApi.java
@@ -48,7 +48,6 @@ public interface CategoryApi {
     )
     @Parameter(
             in = ParameterIn.HEADER,
-            name = "Authorization", required = true,
             schema = @Schema(type = "string"),
             description = "Bearer [Access 토큰]")
     @ApiResponses(value = {

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/category/controller/api/CategoryApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/category/controller/api/CategoryApi.java
@@ -34,7 +34,7 @@ public interface CategoryApi {
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CategoryResponse.CategoryInformationResponse.class)))
     })
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE) // 이 부분에 주목하세요, 이제 multipart/form-data를 소비한다고 명시합니다.
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResponseEntity<CategoryResponse.CategoryInformationResponse> createCategory(
             @Parameter(description = "멤버의 ID", required = true) @PathVariable Long memberId,
             @Parameter(description = "카테고리 이미지 파일", required = true, schema = @Schema(type = "string", format = "binary")) @RequestPart(value = "categoryImage", required = false) MultipartFile categoryImage,
@@ -44,10 +44,10 @@ public interface CategoryApi {
 
     @Operation(summary = "멤버의 모든 카테고리 조회",
             description = "멤버 ID를 받아 해당 멤버의 모든 카테고리를 조회합니다."
-
     )
     @Parameter(
             in = ParameterIn.HEADER,
+            name = "Authorization", required = false,
             schema = @Schema(type = "string"),
             description = "Bearer [Access 토큰]")
     @ApiResponses(value = {
@@ -55,6 +55,7 @@ public interface CategoryApi {
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CategoryResponse.CategoryListResponse.class)))
     })
+    @GetMapping("/{memberId}")
     ResponseEntity<CategoryResponse.CategoryListResponse> getCategoriesByMember(
             @Parameter(description = "멤버의 ID", required = true) @PathVariable Long memberId
     );
@@ -71,6 +72,7 @@ public interface CategoryApi {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "추가 성공")
     })
+    @PostMapping("/{categoryId}/answers/{answerId}")
     ResponseEntity<Void> addAnswerToCategory(
             @Parameter(description = "카테고리의 ID", required = true) @PathVariable Long categoryId,
             @Parameter(description = "답변의 ID", required = true) @PathVariable Long answerId
@@ -88,6 +90,7 @@ public interface CategoryApi {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "수정 성공")
     })
+    @PatchMapping("/{categoryId}/image")
     ResponseEntity<CategoryResponse.CategoryInformationResponse> updateCategoryImage(
             @Parameter(description = "카테고리의 ID", required = true) @PathVariable Long categoryId,
             @Parameter(description = "이미지 파일", required = true) @RequestPart("imageFile") MultipartFile imageFile
@@ -107,6 +110,7 @@ public interface CategoryApi {
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CategoryResponse.CategoryInformationResponse.class)))
     })
+    @PatchMapping("/{categoryId}/image")
     ResponseEntity<CategoryResponse.CategoryInformationResponse> updateCategory(
             @Parameter(description = "카테고리의 ID", required = true) @PathVariable Long categoryId,
             @Parameter(description = "수정할 카테고리 정보", required = true) @RequestBody CategoryRequest.UpdateCategory updateCategory
@@ -124,6 +128,7 @@ public interface CategoryApi {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "삭제 성공")
     })
+    @DeleteMapping("/{categoryId}")
     ResponseEntity<Void> deleteCategory(
             @Parameter(description = "카테고리의 ID", required = true) @PathVariable Long categoryId
     );

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/reaction/dto/ReactionResponse.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/reaction/dto/ReactionResponse.java
@@ -2,6 +2,7 @@ package com.web.baebaeBE.domain.reaction.dto;
 
 import com.web.baebaeBE.domain.answer.entity.Answer;
 import com.web.baebaeBE.domain.reaction.entity.MemberAnswerReaction;
+import jakarta.persistence.criteria.CriteriaBuilder;
 import lombok.*;
 
 public class ReactionResponse {
@@ -12,15 +13,17 @@ public class ReactionResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class CountReactionInformationDto {
-        private int heartCount;
-        private int curiousCount;
-        private int sadCount;
+        private Integer heartCount;
+        private Integer curiousCount;
+        private Integer sadCount;
+        private Integer connectCount;
 
         public static CountReactionInformationDto of(Answer answer) {
             return CountReactionInformationDto.builder()
                     .heartCount(answer.getHeartCount())
                     .curiousCount(answer.getCuriousCount())
                     .sadCount(answer.getSadCount())
+                    .connectCount(answer.getConnectCount())
                     .build();
         }
     }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/reaction/dto/ReactionResponse.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/reaction/dto/ReactionResponse.java
@@ -11,6 +11,24 @@ public class ReactionResponse {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class CountReactionInformationDto {
+        private int heartCount;
+        private int curiousCount;
+        private int sadCount;
+
+        public static CountReactionInformationDto of(Answer answer) {
+            return CountReactionInformationDto.builder()
+                    .heartCount(answer.getHeartCount())
+                    .curiousCount(answer.getCuriousCount())
+                    .sadCount(answer.getSadCount())
+                    .build();
+        }
+    }
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class ReactionInformationDto {
         private boolean isClicked;
         private int heartCount;

--- a/baebae-BE/src/main/java/com/web/baebaeBE/global/security/SecurityConstants.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/global/security/SecurityConstants.java
@@ -8,6 +8,7 @@ public final class SecurityConstants {
             "/api/auth/login", "/api/auth/isExisting", "/api/auth/nickname/isExisting",
             "/api/member/profile-image/{memberId}", "/api/member/nickname/{nickname}",
             "/api/category/{memberId}", "/api/answers", "/api/answers/member/{memberId}",
+            "/api/answers/{answerId}/reactionsCount",
             // Swagger 제외 과정
             "/v3/**", "/swagger-ui/**",
             // Error 페이지


### PR DESCRIPTION
### #️⃣연관된 이슈
> #39 

### 📝PR 설명
기존에 answer 전체 조회시 반응 개수가 함께 조회되도록 구현했지만, 프론트 요청으로 반응 개수를 따로 조회하는 api를 구현하였습니다. answerId를 참조하여 반응 개수가 조회되도록 하였습니다.
이외에도, 답변 수정시 이미지 파일을 선택하도록 하여 수정 자유도를 높였습니다.

### 🔨작업 내용
- [ ] 답변 Id 기반으로 반응 개수 조회하는 api
- [ ] 답변 수정시 이미지 파일 선택여부

### 💎결과 (사진 및 작업 결과)
