### PR TITLE
fix: 전체 피드 조회 url 수정

### DIFF
--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/controller/AnswerController.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/controller/AnswerController.java
@@ -33,15 +33,15 @@ public class AnswerController implements AnswerApi {
         return ResponseEntity.ok(createdAnswer);
     }
 
-    @GetMapping("/member/{memberId}")
+    @GetMapping("/member/{memberId}/list")
     public ResponseEntity<List<AnswerResponse>> getAnswersByMemberId(@PathVariable Long memberId) {
         List<AnswerResponse> answers = answerService.getAnswersByMemberId(memberId);
         return ResponseEntity.ok(answers);
     }
 
-    @GetMapping()
+    @GetMapping("/member/{memberId}/all")
     public ResponseEntity<Page<AnswerDetailResponse>> getAllAnswers(
-            @RequestParam Long memberId,
+            @PathVariable Long memberId,
             @RequestParam(required = false) Long categoryId,
             Pageable pageable) {
 

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/controller/api/AnswerApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/controller/api/AnswerApi.java
@@ -64,12 +64,17 @@ public interface AnswerApi {
             summary = "모든 답변 조회",
             description = "모든 답변을 페이지네이션으로 조회합니다."
     )
+    @Parameter(
+            in = ParameterIn.HEADER,
+            name = "Authorization", required = false,
+            schema = @Schema(type = "string"),
+            description = "Bearer [Access 토큰]")
     @ApiResponse(responseCode = "200", description = "답변 조회 성공",
             content = @Content(mediaType = "application/json",
                     schema = @Schema(implementation = Page.class)))
-    @GetMapping
+    @RequestMapping(method = RequestMethod.GET)
     ResponseEntity<Page<AnswerDetailResponse>> getAllAnswers(
-            @RequestParam Long memberId,
+            @PathVariable Long memberId,
             @RequestParam(required = false) Long category,
             Pageable pageable);
     @Operation(


### PR DESCRIPTION
### #️⃣연관된 이슈
> #39 

### 📝PR 설명
기존에 전체 피드를 조회하던 getAllAnswers에서 memberId와 categoryId를 쿼리파라미터로 지정하였습니다.
이를 memberId를 경로변수로, categoryId를 쿼리파라미터로 지정하여 url을 변경하였습니다.

### 🔨작업 내용
- [ ] url 수정(기존에 피드 리스트 조회와 모든 피드 조회의 url이 겹쳐 수정)


### 💎결과 (사진 및 작업 결과)
