### PR TITLE
fix: Question, Answer api 수정

### DIFF
--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/controller/AnswerController.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/controller/AnswerController.java
@@ -42,13 +42,6 @@ public class AnswerController implements AnswerApi {
         return ResponseEntity.ok(answerService.getAllAnswers(memberId, categoryId, pageable));
     }
 
-    @PutMapping(value = "/{answerId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<AnswerDetailResponse> updateAnswer(@PathVariable Long answerId,
-                                                             @RequestPart(value = "imageFile", required = false) MultipartFile imageFile,
-                                                             @RequestPart AnswerCreateRequest request) {
-        AnswerDetailResponse updatedAnswer = answerService.updateAnswer(answerId, request, imageFile);
-        return ResponseEntity.ok(updatedAnswer);
-    }
 
     @DeleteMapping("/{answerId}")
     public ResponseEntity<Void> deleteAnswer(@PathVariable Long answerId) {

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/controller/api/AnswerApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/controller/api/AnswerApi.java
@@ -62,24 +62,6 @@ public interface AnswerApi {
             @PathVariable Long memberId,
             @RequestParam(required = false) Long category,
             Pageable pageable);
-    @Operation(
-            summary = "답변 수정",
-            description = "기존 답변을 수정합니다.",
-            security = @SecurityRequirement(name = "bearerAuth")
-    )
-    @Parameter(
-            in = ParameterIn.HEADER,
-            name = "Authorization", required = true,
-            schema = @Schema(type = "string"),
-            description = "Bearer [Access 토큰]")
-    @ApiResponse(responseCode = "201", description = "답변 수정 성공",
-            content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = AnswerDetailResponse.class)))
-    @PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    ResponseEntity<AnswerDetailResponse> updateAnswer(
-            @PathVariable Long answerId,
-            @RequestPart(value = "imageFile", required = false) MultipartFile imageFile,
-            @RequestPart AnswerCreateRequest request);
 
     @Operation(
             summary = "답변 삭제",

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/dto/AnswerCreateRequest.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/dto/AnswerCreateRequest.java
@@ -8,7 +8,6 @@ import lombok.*;
 @NoArgsConstructor
 public class AnswerCreateRequest {
     private Long questionId;
-    private String nickname;
     private Boolean profileOnOff;
     private String content;
     private String linkAttachments;
@@ -20,12 +19,11 @@ public class AnswerCreateRequest {
 
 
 
-    public AnswerCreateRequest(Long questionId, String content,String nickname,
+    public AnswerCreateRequest(Long questionId, String content,
                                Boolean profileOnOff, String linkAttachments,
                                String musicName, String musicSinger, String musicAudioUrl, String imageUrl, boolean updateImage) {
         this.questionId = questionId;
         this.content = content;
-        this.nickname = nickname;
         this.profileOnOff = profileOnOff;
         this.linkAttachments = linkAttachments;
         this.musicName = musicName;
@@ -36,10 +34,10 @@ public class AnswerCreateRequest {
 
     }
 
-    public static AnswerCreateRequest of(Long questionId, String content, String  nickname,
+    public static AnswerCreateRequest of(Long questionId, String content,
                                          Boolean profileOnOff, String linkAttachments,
                                          String musicName, String musicSinger, String musicAudioUrl, String imageUrl, boolean updateImage) {
-        return new AnswerCreateRequest(questionId, content, nickname, profileOnOff, linkAttachments,
+        return new AnswerCreateRequest(questionId, content, profileOnOff, linkAttachments,
                 musicName, musicSinger, musicAudioUrl, imageUrl, updateImage);
     }
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/dto/AnswerDetailResponse.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/dto/AnswerDetailResponse.java
@@ -13,8 +13,7 @@ public class AnswerDetailResponse {
     private String questionContent;
     private Long memberId;
     private String content;
-    private String senderNickname;
-    private String nickname;
+    private String memberNickname;
     private Boolean profileOnOff;
     private String linkAttachments;
     private String musicName;
@@ -25,7 +24,7 @@ public class AnswerDetailResponse {
 
 
     public AnswerDetailResponse(Long answerId, Long questionId, String questionContent, Long memberId,
-                                String content, String senderNickname, String nickname, Boolean profileOnOff,
+                                String content, String memberNickname, Boolean profileOnOff,
                                 String linkAttachments, String musicName, String musicSinger, String musicAudioUrl,
                                  String imageUrl, LocalDateTime createdDate) {
 
@@ -35,8 +34,7 @@ public class AnswerDetailResponse {
         this.questionContent = questionContent;
         this.memberId = memberId;
         this.content = content;
-        this.senderNickname = senderNickname;
-        this.nickname = nickname;
+        this.memberNickname = memberNickname;
         this.profileOnOff = profileOnOff;
         this.linkAttachments = linkAttachments;
         this.musicName = musicName;
@@ -47,11 +45,11 @@ public class AnswerDetailResponse {
     }
 
     public static AnswerDetailResponse of(Long answerId, Long questionId, String questionContent, Long memberId,
-                                          String content, String memberNickname, String nickname, Boolean profileOnOff,
+                                          String content, String memberNickname, Boolean profileOnOff,
                                           String linkAttachments, String musicName, String musicSinger, String musicAudioUrl,
                                           String imageUrl, LocalDateTime createdDate) {
         return new AnswerDetailResponse(answerId, questionId, questionContent, memberId, content, memberNickname,
-                nickname, profileOnOff, linkAttachments, musicName, musicSinger, musicAudioUrl, imageUrl, createdDate);
+                 profileOnOff, linkAttachments, musicName, musicSinger, musicAudioUrl, imageUrl, createdDate);
 
       
     }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/entity/Answer.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/entity/Answer.java
@@ -37,8 +37,6 @@ public class Answer {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
-    @Column(name = "nickname")
-    private String nickname;
 
     @Column(name = "image_file")
     private String imageFile;  // 이미지 파일 경로를 저장하는 리스트
@@ -67,10 +65,10 @@ public class Answer {
     @Column(name = "profile_on_off", nullable = false)
     private boolean profileOnOff;
 
-    public static Answer of(Long id, Question question, Member member, String nickname, String content,
+    public static Answer of(Long id, Question question, Member member, String content,
                             String imageFile, Music music, String linkAttachments, String imageUrl, LocalDateTime createdDate,
                             ReactionCount reactionCount, boolean profileOnOff) {
-        return new Answer(id, question, member, nickname, imageFile, content, music, linkAttachments, imageUrl, createdDate, null, reactionCount, profileOnOff);
+        return new Answer(id, question, member, imageFile, content, music, linkAttachments, imageUrl, createdDate, null, reactionCount, profileOnOff);
     }
 
 }

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/repository/AnswerMapper.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/repository/AnswerMapper.java
@@ -28,7 +28,6 @@ public class AnswerMapper {
         Answer answer = Answer.builder()
                 .question(question)
                 .member(member)
-                .nickname(request.getNickname())
                 .content(request.getContent())
                 .linkAttachments(request.getLinkAttachments())
                 .profileOnOff(request.getProfileOnOff())
@@ -53,8 +52,7 @@ public class AnswerMapper {
                 question.getContent(),
                 member.getId(),
                 answer.getContent(),
-                question.getSender().getNickname(),
-                answer.getNickname(),
+                member.getNickname(),
                 answer.isProfileOnOff(),
                 answer.getLinkAttachments(),
                 music != null ? music.getMusicName() : null,

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/service/AnswerService.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/answer/service/AnswerService.java
@@ -1,7 +1,6 @@
 package com.web.baebaeBE.domain.answer.service;
 
 import com.web.baebaeBE.domain.answer.dto.AnswerDetailResponse;
-import com.web.baebaeBE.domain.answer.dto.AnswerResponse;
 import com.web.baebaeBE.domain.answer.exception.AnswerError;
 import com.web.baebaeBE.domain.answer.repository.AnswerMapper;
 import com.web.baebaeBE.domain.categorized.answer.entity.CategorizedAnswer;
@@ -33,9 +32,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -100,13 +97,6 @@ public class AnswerService {
         return answerMapper.toDomain(savedAnswer);
     }
 
-    @Transactional
-    public List<AnswerResponse> getAnswersByMemberId(Long memberId) {
-        List<Answer> answers = answerRepository.findByMemberId(memberId);
-        return answers.stream()
-                .map(answerMapper::toResponse)
-                .collect(Collectors.toList());
-    }
 
     @Transactional
     public Page<AnswerDetailResponse> getAllAnswers(Long memberId, Long categoryId, Pageable pageable) {
@@ -118,36 +108,6 @@ public class AnswerService {
             Page<Answer> answerPage = categorizedAnswerPage.map(CategorizedAnswer::getAnswer);
             return answerPage.map(answerMapper::toDomain);
         }
-    }
-
-    @Transactional
-    public AnswerDetailResponse updateAnswer(Long answerId, AnswerCreateRequest request, MultipartFile imageFile) {
-        Answer answer = answerRepository.findByAnswerId(answerId)
-                .orElseThrow(() -> new BusinessException(AnswerError.NO_EXIST_ANSWER));
-        answer.setContent(request.getContent());
-        answer.setLinkAttachments(request.getLinkAttachments());
-
-        // Music 엔티티 업데이트
-        answer.getMusic().setMusicName(request.getMusicName());
-        answer.getMusic().setMusicSinger(request.getMusicSinger());
-        answer.getMusic().setMusicAudioUrl(request.getMusicAudioUrl());
-
-        if (request.isUpdateImage() && imageFile != null && !imageFile.isEmpty()) {
-            try (InputStream inputStream = imageFile.getInputStream()) {
-                String imageUrl = s3ImageStorageService.uploadFile(answer.getMember().getId().toString(), answerId.toString(), "image", 0, inputStream, imageFile.getSize(), imageFile.getContentType());
-                answer.setImageFile(imageUrl);
-            } catch (IOException e) {
-                throw new BusinessException(AnswerError.IMAGE_PROCESSING_ERROR);
-            }
-        }
-
-        // 질문의 isAnswered 상태를 true로 업데이트
-        Question question = answer.getQuestion();
-        question.setAnswered(true);
-
-        questionRepository.save(question);
-        answer = answerRepository.save(answer);
-        return answerMapper.toDomain(answer);
     }
 
     @Transactional

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/controller/QuestionController.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/controller/QuestionController.java
@@ -3,6 +3,7 @@ package com.web.baebaeBE.domain.question.controller;
 import com.web.baebaeBE.domain.question.controller.api.QuestionApi;
 import com.web.baebaeBE.domain.question.dto.QuestionCreateRequest;
 import com.web.baebaeBE.domain.question.dto.QuestionDetailResponse;
+import com.web.baebaeBE.domain.question.dto.QuestionUpdateRequest;
 import com.web.baebaeBE.domain.question.service.QuestionService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -51,8 +52,8 @@ public class QuestionController implements QuestionApi {
 
     @PutMapping("/{questionId}")
     public ResponseEntity<Void> updateQuestion(
-            @PathVariable Long questionId, @RequestParam String content) {
-        questionService.updateQuestion(questionId, content);
+            @PathVariable Long questionId, @RequestBody QuestionUpdateRequest request) {
+        questionService.updateQuestion(questionId, request);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
     }
 

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/controller/api/QuestionApi.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/controller/api/QuestionApi.java
@@ -2,6 +2,7 @@ package com.web.baebaeBE.domain.question.controller.api;
 
 import com.web.baebaeBE.domain.question.dto.QuestionCreateRequest;
 import com.web.baebaeBE.domain.question.dto.QuestionDetailResponse;
+import com.web.baebaeBE.domain.question.dto.QuestionUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -110,8 +111,7 @@ public interface QuestionApi {
                             "}")))
     @PutMapping("/{questionId}")
     ResponseEntity<Void> updateQuestion(
-            @PathVariable Long questionId,
-            @RequestParam String content);
+            @PathVariable Long questionId, @RequestBody QuestionUpdateRequest request);
 
     @Operation(
             summary = "질문 삭제",

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/dto/QuestionUpdateRequest.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/dto/QuestionUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.web.baebaeBE.domain.question.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+@Getter
+@Setter
+@NoArgsConstructor
+public class QuestionUpdateRequest {
+    private String content;
+    private String nickname;
+
+    public QuestionUpdateRequest(String content,String nickname) {
+        this.content = content;
+        this.nickname = nickname;
+    }
+    public static QuestionUpdateRequest of( String content, String nickname) {
+        return new QuestionUpdateRequest(content, nickname);
+    }
+}

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/entity/Question.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/entity/Question.java
@@ -46,6 +46,7 @@ public class Question {
 
     public void updateContent(String content) {
         this.content = content;
+
     }
 
 

--- a/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/service/QuestionService.java
+++ b/baebae-BE/src/main/java/com/web/baebaeBE/domain/question/service/QuestionService.java
@@ -5,6 +5,7 @@ import com.web.baebaeBE.domain.member.entity.Member;
 import com.web.baebaeBE.domain.member.repository.MemberRepository;
 import com.web.baebaeBE.domain.question.dto.QuestionCreateRequest;
 import com.web.baebaeBE.domain.question.dto.QuestionDetailResponse;
+import com.web.baebaeBE.domain.question.dto.QuestionUpdateRequest;
 import com.web.baebaeBE.domain.question.exception.QuestionError;
 import com.web.baebaeBE.domain.question.repository.QuestionMapper;
 import com.web.baebaeBE.global.error.exception.BusinessException;
@@ -49,13 +50,12 @@ public class QuestionService {
     }
 
     @Transactional
-    public QuestionDetailResponse updateQuestion(Long questionId, String content) {
+    public QuestionDetailResponse updateQuestion(Long questionId, QuestionUpdateRequest request) {
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new BusinessException(QuestionError.NO_EXIST_QUESTION));
-        question.updateContent(content);
+        question.updateContent(question.getContent());
+        question.setNickname(request.getNickname()); // 닉네임 업데이트
         Question updatedQuestion = questionRepository.save(question);
-
-        //firebaseNotificationService.notifyNewQuestion(updatedQuestion.getSender(), updatedQuestion); // 파이어베이스 메세지 송신
 
         return questionMapper.toDomain(updatedQuestion);
     }


### PR DESCRIPTION
### #️⃣연관된 이슈
> #34 
> #39 

### 📝PR 설명
1. Question에 질문 수정시 content와 nickname 모두 수정 가능하게 하였습니다.
2. Question 수정시 쿼리파라미터로 받는 것을 request body로 수정하였습니다.
3. Answer에 nickname 제거
4. Answer 컨트롤러에서 피드 수정 api 제거

### 🔨작업 내용
- [ ] Question(수정시 request body로, nickname 수정 추가)
- [ ] Answer(nickname제거, 피드 수정 api 제거)

### 💎결과 (사진 및 작업 결과)
